### PR TITLE
added sql for count, struct updated

### DIFF
--- a/database/snippets/migration_27_instrument_groups_and_misc.sql
+++ b/database/snippets/migration_27_instrument_groups_and_misc.sql
@@ -3,8 +3,8 @@
 ALTER TABLE timeseries_measurement ADD PRIMARY KEY (timeseries_id, time);
 
 --add new view for instrument_groups
--- v_instrument_groups
-CREATE OR REPLACE VIEW v_instrument_groups AS (
+-- v_instrument_group
+CREATE OR REPLACE VIEW v_instrument_group AS (
     WITH instrument_count AS (
         SELECT 
         igi.instrument_group_id,
@@ -45,4 +45,4 @@ CREATE OR REPLACE VIEW v_instrument_groups AS (
 
 -- grant select on new view
 
-GRANT SELECT ON v_instrument_groups TO instrumentation_reader;
+GRANT SELECT ON v_instrument_group TO instrumentation_reader;

--- a/database/snippets/migration_27_instrument_groups_and_misc.sql
+++ b/database/snippets/migration_27_instrument_groups_and_misc.sql
@@ -1,0 +1,48 @@
+
+-- timeseries_measurements - add primary key which should also index
+ALTER TABLE timeseries_measurement ADD PRIMARY KEY (timeseries_id, time);
+
+--add new view for instrument_groups
+-- v_instrument_groups
+CREATE OR REPLACE VIEW v_instrument_groups AS (
+    WITH instrument_count AS (
+        SELECT 
+        igi.instrument_group_id,
+        count(igi.instrument_group_id) as i_count 
+        FROM instrument_group_instruments igi
+        JOIN instrument i on igi.instrument_id = i.id and not i.deleted
+        GROUP BY igi.instrument_group_id
+        )
+        ,
+        timeseries_instruments as (
+            SELECT t.id, t.instrument_id, igi.instrument_group_id from timeseries t 
+            JOIN instrument i on i.id = t.instrument_id and not i.deleted
+            JOIN instrument_group_instruments igi on igi.instrument_id = i.id
+        )
+
+        SELECT  ig.id,
+                ig.slug,
+                ig.name,
+                ig.description,
+                ig.creator,
+                ig.create_date,
+                ig.updater,
+                ig.update_date,
+                ig.project_id,
+                ig.deleted,
+                COALESCE(ic.i_count,0) as instrument_count,
+                COALESCE(count(ti.id),0) as timeseries_count
+                --,
+                --COALESCE(count(tm.id),0) as timeseries_measurements_count
+                
+        FROM instrument_group ig
+        LEFT JOIN instrument_count ic on ic.instrument_group_id = ig.id
+        LEFT JOIN timeseries_instruments ti on ig.id = ti.instrument_group_id
+        --left join timeseries_measurement tm on tm.timeseries_id = ti.id
+        GROUP BY ig.id, ic.i_count
+        ORDER BY ig.name
+);
+
+-- grant select on new view
+
+GRANT SELECT ON v_instrument_groups TO instrumentation_reader;

--- a/database/sql/10-tables.sql
+++ b/database/sql/10-tables.sql
@@ -254,11 +254,12 @@ CREATE TABLE IF NOT EXISTS public.timeseries (
 
 -- timeseries_measurement
 CREATE TABLE IF NOT EXISTS public.timeseries_measurement (
-    id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+    --id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
     time TIMESTAMPTZ NOT NULL,
     value REAL NOT NULL,
     timeseries_id UUID NOT NULL REFERENCES timeseries (id) ON DELETE CASCADE,
-    CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id,time)
+    CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id,time),
+    PRIMARY KEY (timeseries_id, time)
 );
 
 -- instrument_constants

--- a/database/sql/15-views.sql
+++ b/database/sql/15-views.sql
@@ -239,7 +239,7 @@ CREATE OR REPLACE VIEW v_plot_configuration AS (
 );
 
 -- v_instrument_groups
-CREATE OR REPLACE VIEW v_instrument_groups AS (
+CREATE OR REPLACE VIEW v_instrument_group AS (
     WITH instrument_count AS (
         SELECT 
         igi.instrument_group_id,

--- a/database/sql/15-views.sql
+++ b/database/sql/15-views.sql
@@ -277,3 +277,40 @@ CREATE OR REPLACE VIEW v_instrument_groups AS (
         GROUP BY ig.id, ic.i_count
         ORDER BY ig.name
 );
+
+-- v_profile_project_roles
+CREATE OR REPLACE VIEW v_profile_project_roles AS (
+    SELECT a.id,
+           a.profile_id,
+           b.edipi,
+           b.username,
+           b.email,
+           b.is_admin,
+           c.id AS project_id,
+           r.id   AS role_id,
+           r.name AS role,
+           UPPER(c.slug || '.' || r.name) AS rolename
+    FROM profile_project_roles a
+    INNER JOIN profile b ON b.id = a.profile_id
+    INNER JOIN project c ON c.id = a.project_id
+    INNER JOIN role    r ON r.id = a.role_id
+    ORDER BY username, role
+);
+
+CREATE OR REPLACE VIEW v_profile AS (
+    WITH roles_by_profile AS (
+        SELECT profile_id,
+               array_agg(UPPER(b.slug || '.' || c.name)) AS roles
+        FROM profile_project_roles a
+        LEFT JOIN project b ON a.project_id = b.id
+        LEFT JOIN role    c ON a.role_id    = c.id
+        GROUP BY profile_id
+    )
+    SELECT p.id,
+           p.edipi,
+           p.username,
+           p.email,
+           p.is_admin,
+           COALESCE(r.roles,'{}') AS roles
+    FROM profile p
+    LEFT JOIN roles_by_profile r ON r.profile_id = p.id

--- a/database/sql/15-views.sql
+++ b/database/sql/15-views.sql
@@ -237,3 +237,43 @@ CREATE OR REPLACE VIEW v_plot_configuration AS (
         GROUP BY plot_configuration_id
     ) as t ON pc.id = t.plot_configuration_id
 );
+
+-- v_instrument_groups
+CREATE OR REPLACE VIEW v_instrument_groups AS (
+    WITH instrument_count AS (
+        SELECT 
+        igi.instrument_group_id,
+        count(igi.instrument_group_id) as i_count 
+        FROM instrument_group_instruments igi
+        JOIN instrument i on igi.instrument_id = i.id and not i.deleted
+        GROUP BY igi.instrument_group_id
+        )
+        ,
+        timeseries_instruments as (
+            SELECT t.id, t.instrument_id, igi.instrument_group_id from timeseries t 
+            JOIN instrument i on i.id = t.instrument_id and not i.deleted
+            JOIN instrument_group_instruments igi on igi.instrument_id = i.id
+        )
+
+        SELECT  ig.id,
+                ig.slug,
+                ig.name,
+                ig.description,
+                ig.creator,
+                ig.create_date,
+                ig.updater,
+                ig.update_date,
+                ig.project_id,
+                ig.deleted,
+                COALESCE(ic.i_count,0) as instrument_count,
+                COALESCE(count(ti.id),0) as timeseries_count
+                --,
+                --COALESCE(count(tm.id),0) as timeseries_measurements_count
+                
+        FROM instrument_group ig
+        LEFT JOIN instrument_count ic on ic.instrument_group_id = ig.id
+        LEFT JOIN timeseries_instruments ti on ig.id = ti.instrument_group_id
+        --left join timeseries_measurement tm on tm.timeseries_id = ti.id
+        GROUP BY ig.id, ic.i_count
+        ORDER BY ig.name
+);

--- a/database/sql/20-roles.sql
+++ b/database/sql/20-roles.sql
@@ -49,7 +49,7 @@ GRANT SELECT ON
     unit,
     unit_family,
     v_instrument,
-    v_instrument_groups,
+    v_instrument_group,
     v_plot_configuration,
     v_project,
     v_timeseries,

--- a/database/sql/20-roles.sql
+++ b/database/sql/20-roles.sql
@@ -49,6 +49,7 @@ GRANT SELECT ON
     unit,
     unit_family,
     v_instrument,
+    v_instrument_groups,
     v_plot_configuration,
     v_project,
     v_timeseries,

--- a/dbutils/tables.go
+++ b/dbutils/tables.go
@@ -105,10 +105,10 @@ func createTableTimeseries(db *sqlx.DB) {
 func createTableTimeseriesMeasurement(db *sqlx.DB) {
 	sql := `
 	CREATE TABLE IF NOT EXISTS public.timeseries_measurement (
-		id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
 		time TIMESTAMPTZ NOT NULL,
 		value REAL NOT NULL,
-		timeseries_id UUID NOT NULL REFERENCES unit (id)
+		timeseries_id UUID NOT NULL REFERENCES unit (id),
+		PRIMARY KEY (timeseries_id, time)
 	);
 	`
 	_, err := db.Exec(sql)

--- a/handlers/home.go
+++ b/handlers/home.go
@@ -27,7 +27,7 @@ func GetHome(db *sqlx.DB) echo.HandlerFunc {
 		            (SELECT count(id) FROM instrument_group)                    AS instrument_group_count,
 					(SELECT count(id) FROM instrument
 					  WHERE NOT deleted and (now() - create_date) < '7 Days')   AS new_instruments_7d,
-					(SELECT count(id) FROM timeseries_measurement
+					(SELECT count(timeseries_id) FROM timeseries_measurement
 					  WHERE (now() - timeseries_measurement.time) < '2 Hours' ) AS new_measurements_2h
 			`,
 		); err != nil {

--- a/models/domains.go
+++ b/models/domains.go
@@ -42,6 +42,12 @@ func GetDomains(db *sqlx.DB) ([]Domain, error) {
 				   name                AS value,
 				   description
 			FROM   status
+			UNION
+			SELECT id,
+			       'role' AS group,
+				   name   AS value,
+				   null   AS description
+			FROM   role
 			order by "group", value
 	`
 	if err := db.Select(&dd, sql); err != nil {

--- a/models/domains.go
+++ b/models/domains.go
@@ -42,6 +42,7 @@ func GetDomains(db *sqlx.DB) ([]Domain, error) {
 				   name                AS value,
 				   description
 			FROM   status
+			order by "group", value
 	`
 	if err := db.Select(&dd, sql); err != nil {
 		return make([]Domain, 0), err

--- a/models/instrument_groups.go
+++ b/models/instrument_groups.go
@@ -214,4 +214,4 @@ var listInstrumentGroupsSQL = `SELECT id,
 				                      project_id,
 									  instrument_count,
 									  timeseries_count 
-	                            FROM  v_instrument_groups`
+	                            FROM  v_instrument_group`

--- a/models/instrument_groups.go
+++ b/models/instrument_groups.go
@@ -16,6 +16,7 @@ type InstrumentGroup struct {
 	Name        string     `json:"name"`
 	Description string     `json:"description"`
 	ProjectID   *uuid.UUID `json:"project_id" db:"project_id"`
+	InstrumentCount int    `json:"instrument_count" db:"instrument_count"`
 	AuditInfo
 }
 
@@ -209,5 +210,10 @@ var listInstrumentGroupsSQL = `SELECT id,
 				                      create_date,
 				                      updater,
 				                      update_date,
-				                      project_id
+				                      project_id,
+									  (select count(id) from instrument i
+									  	join instrument_group_instruments gi on gi.instrument_id = i.id
+									  	where gi.instrument_group_id = instrument_group.id
+									  	and i.deleted is false) 
+									  as instrument_count
 	                            FROM   instrument_group`

--- a/models/instrument_groups.go
+++ b/models/instrument_groups.go
@@ -17,6 +17,7 @@ type InstrumentGroup struct {
 	Description string     `json:"description"`
 	ProjectID   *uuid.UUID `json:"project_id" db:"project_id"`
 	InstrumentCount int    `json:"instrument_count" db:"instrument_count"`
+	TimeseriesCount int    `json:"timeseries_count" db:"timeseries_count"`
 	AuditInfo
 }
 
@@ -211,9 +212,6 @@ var listInstrumentGroupsSQL = `SELECT id,
 				                      updater,
 				                      update_date,
 				                      project_id,
-									  (select count(id) from instrument i
-									  	join instrument_group_instruments gi on gi.instrument_id = i.id
-									  	where gi.instrument_group_id = instrument_group.id
-									  	and i.deleted is false) 
-									  as instrument_count
-	                            FROM   instrument_group`
+									  instrument_count,
+									  timeseries_count 
+	                            FROM  v_instrument_groups`

--- a/models/timeseries_measurements.go
+++ b/models/timeseries_measurements.go
@@ -101,8 +101,7 @@ func CreateOrUpdateTimeseriesMeasurements(db *sqlx.DB, mc []ts.MeasurementCollec
 }
 
 func listTimeseriesMeasurementsSQL() string {
-	return `SELECT  M.id,
-	                M.timeseries_id,
+	return `SELECT  M.timeseries_id,
 			        M.time,
 					M.value
 			FROM timeseries_measurement M

--- a/timeseries/timeseries.go
+++ b/timeseries/timeseries.go
@@ -27,7 +27,6 @@ type Timeseries struct {
 
 // Measurement is a time and value associated with a timeseries
 type Measurement struct {
-	ID           string    `json:"id,omitempty"`
 	TimeseriesID uuid.UUID `json:"-" db:"timeseries_id"`
 	Time         time.Time `json:"time"`
 	Value        float32   `json:"value"`


### PR DESCRIPTION
listInstrumentGroupsSQL was modified, but should stay flexible for other calls by **ListInstrumentGroups** and **GetInstrumentGroup** which both append sql like `WHERE NOT DELETED` or `WHERE id = $1`.  New query also ensures only active (non-deleted) instruments are being counted.