### PR TITLE
Bugfix/collection group join

### DIFF
--- a/models/collection_group.go
+++ b/models/collection_group.go
@@ -56,7 +56,6 @@ func ListCollectionGroupSlugs(db *sqlx.DB, projectID *uuid.UUID) ([]string, erro
 }
 
 // GetCollectionGroupDetails returns details for a single CollectionGroup
-// GetCollectionGroupDetails returns details for a single CollectionGroup
 func GetCollectionGroupDetails(db *sqlx.DB, projectID *uuid.UUID, collectionGroupID *uuid.UUID) (*CollectionGroupDetails, error) {
 	var d CollectionGroupDetails
 	// Query 1

--- a/models/collection_group.go
+++ b/models/collection_group.go
@@ -56,6 +56,7 @@ func ListCollectionGroupSlugs(db *sqlx.DB, projectID *uuid.UUID) ([]string, erro
 }
 
 // GetCollectionGroupDetails returns details for a single CollectionGroup
+// GetCollectionGroupDetails returns details for a single CollectionGroup
 func GetCollectionGroupDetails(db *sqlx.DB, projectID *uuid.UUID, collectionGroupID *uuid.UUID) (*CollectionGroupDetails, error) {
 	var d CollectionGroupDetails
 	// Query 1
@@ -70,7 +71,7 @@ func GetCollectionGroupDetails(db *sqlx.DB, projectID *uuid.UUID, collectionGrou
 		FROM collection_group_timeseries cgt 
 		INNER JOIN collection_group cg on cg.id = cgt.collection_group_id 
 		INNER JOIN v_timeseries t on t.id = cgt.timeseries_id 
-		INNER JOIN timeseries_measurement tm on tm.timeseries_id = t.id and tm.time = (
+		LEFT JOIN timeseries_measurement tm on tm.timeseries_id = t.id and tm.time = (
 			select time from timeseries_measurement 
 			where timeseries_id = t.id 
 			order by time desc limit 1) 
@@ -79,7 +80,7 @@ func GetCollectionGroupDetails(db *sqlx.DB, projectID *uuid.UUID, collectionGrou
 	); err != nil {
 		return nil, err
 	}
-
+	
 	return &d, nil
 }
 


### PR DESCRIPTION
Hotfix to resolve issue [120](https://github.com/USACE/instrumentation/issues/120)

Left join will always include collection group timeseries even with null latest_time and latest_value