### PR TITLE
Complete SOW A.1.1

### DIFF
--- a/database/snippets/migration_34_inclinometer.sql
+++ b/database/snippets/migration_34_inclinometer.sql
@@ -1,0 +1,23 @@
+-- New table was created.
+CREATE TABLE IF NOT EXISTS timeseries_notes (
+    masked boolean NOT NULL DEFAULT false,
+    validated boolean NOT NULL DEFAULT false,
+    annotation varchar(400) NOT NULL DEFAULT '',
+    timeseries_id UUID NOT NULL REFERENCES timeseries (id) ON DELETE CASCADE,
+    CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id,time),
+    time TIMESTAMPTZ NOT NULL,
+    CONSTRAINT notes_unique_time UNIQUE(timeseries_id, time),
+    PRIMARY KEY (timeseries_id, time)
+);
+
+-- A new column, timeseries_id, was added.
+ALTER TABLE timeseries_measurement ADD COLUMN timeseries_id UUID;
+ALTER TABLE timeseries_measurement ADD CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id, time);
+
+-- Primary key was changed from just "timeseries_id" to "(timeseries_id, time)".
+ALTER TABLE timeseries_measurement DROP CONSTRAINT timeseries_measurement_pk;
+ALTER TABLE timeseries_measurement ADD PRIMARY KEY (timeseries_id, time);
+
+-- Permissions
+GRANT SELECT ON timeseries_notes TO instrumentation_reader;
+GRANT INSERT,UPDATE,DELETE ON timeseries_notes TO instrumentation_writer;

--- a/database/sql/10-tables.sql
+++ b/database/sql/10-tables.sql
@@ -295,9 +295,9 @@ CREATE TABLE IF NOT EXISTS timeseries_notes (
     masked boolean NOT NULL DEFAULT false,
     validated boolean NOT NULL DEFAULT false,
     annotation varchar(400) NOT NULL DEFAULT '',
-    timeseries_id UUID NOT NULL REFERENCES timeseries_measurement (id) ON DELETE CASCADE,
-    time TIMESTAMPTZ NOT NULL REFERENCES timeseries_measurement (time) ON DELETE CASCADE,
-    CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id,time),
+    timeseries_id UUID NOT NULL REFERENCES timeseries (id) ON DELETE CASCADE,
+    time TIMESTAMPTZ NOT NULL,
+    CONSTRAINT notes_unique_time UNIQUE(timeseries_id, time),
     PRIMARY KEY (timeseries_id, time)
 );
 

--- a/database/sql/10-tables.sql
+++ b/database/sql/10-tables.sql
@@ -285,10 +285,18 @@ CREATE TABLE IF NOT EXISTS timeseries_measurement (
     --id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
     time TIMESTAMPTZ NOT NULL,
     value DOUBLE PRECISION NOT NULL,
+    timeseries_id UUID NOT NULL REFERENCES timeseries (id) ON DELETE CASCADE,
+    CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id,time),
+    PRIMARY KEY (timeseries_id, time)
+);
+
+-- timeseries_notes
+CREATE TABLE IF NOT EXISTS timeseries_notes (
     masked boolean NOT NULL DEFAULT false,
     validated boolean NOT NULL DEFAULT false,
     annotation varchar(400) NOT NULL DEFAULT '',
-    timeseries_id UUID NOT NULL REFERENCES timeseries (id) ON DELETE CASCADE,
+    timeseries_id UUID NOT NULL REFERENCES timeseries_measurement (id) ON DELETE CASCADE,
+    time TIMESTAMPTZ NOT NULL REFERENCES timeseries_measurement (time) ON DELETE CASCADE,
     CONSTRAINT timeseries_unique_time UNIQUE(timeseries_id,time),
     PRIMARY KEY (timeseries_id, time)
 );

--- a/database/sql/20-roles.sql
+++ b/database/sql/20-roles.sql
@@ -54,6 +54,7 @@ GRANT SELECT ON
     status,
     timeseries,
     timeseries_measurement,
+    timeseries_notes,
     unit,
     unit_family,
     v_instrument,
@@ -110,6 +111,7 @@ GRANT INSERT,UPDATE,DELETE ON
     telemetry_type,
     timeseries,
     timeseries_measurement,
+    timeseries_notes,
     unit,
     unit_family,
     inclinometer_measurement

--- a/models/timeseries_measurements.go
+++ b/models/timeseries_measurements.go
@@ -134,10 +134,12 @@ func listTimeseriesMeasurementsSQL() string {
 	return `SELECT  M.timeseries_id,
 			        M.time,
 					M.value,
-					M.masked,
-					M.validated,
-					M.annotation
+					N.masked,
+					N.validated,
+					N.annotation
 			FROM timeseries_measurement M
+			INNER JOIN timeseries_notes N
+					ON N.timeseries_id = M.timeseries_id
 			INNER JOIN timeseries T
     			    ON T.id = M.timeseries_id
 	`

--- a/models/timeseries_measurements.go
+++ b/models/timeseries_measurements.go
@@ -99,9 +99,18 @@ func CreateOrUpdateTimeseriesMeasurements(db *sqlx.DB, mc []ts.MeasurementCollec
 		return nil, err
 	}
 
-	stmt, err := txn.Prepare(
-		`INSERT INTO timeseries_measurement (timeseries_id, time, value, masked, validated, annotation) VALUES ($1, $2, $3, $4, $5, $6)
-		 ON CONFLICT ON CONSTRAINT timeseries_unique_time DO UPDATE SET value = EXCLUDED.value, masked = EXCLUDED.masked, validated = EXCLUDED.validated, annotation = EXCLUDED.annotation; 
+	stmt_measurement, err := txn.Prepare(
+		`INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES ($1, $2, $3)
+		 ON CONFLICT ON CONSTRAINT timeseries_unique_time DO UPDATE SET value = EXCLUDED.value; 
+		`,
+	)
+	if err != nil {
+		txn.Rollback()
+		return nil, err
+	}
+	stmt_notes, err := txn.Prepare(
+		`INSERT INTO timeseries_notes (timeseries_id, time, masked, validated, annotation) VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT ON CONSTRAINT notes_unique_time DO UPDATE SET masked = EXCLUDED.masked, validated = EXCLUDED.validated, annotation = EXCLUDED.annotation;
 		`,
 	)
 	if err != nil {
@@ -112,13 +121,21 @@ func CreateOrUpdateTimeseriesMeasurements(db *sqlx.DB, mc []ts.MeasurementCollec
 	// Iterate All Timeseries Measurements
 	for _, c := range mc {
 		for _, m := range c.Items {
-			if _, err := stmt.Exec(c.TimeseriesID, m.Time, m.Value, m.Masked, m.Validated, m.Annotation); err != nil {
+			if _, err := stmt_measurement.Exec(c.TimeseriesID, m.Time, m.Value); err != nil {
+				txn.Rollback()
+				return nil, err
+			}
+			if _, err := stmt_notes.Exec(c.TimeseriesID, m.Time, m.Masked, m.Validated, m.Annotation); err != nil {
 				txn.Rollback()
 				return nil, err
 			}
 		}
 	}
-	if err := stmt.Close(); err != nil {
+	if err := stmt_measurement.Close(); err != nil {
+		txn.Rollback()
+		return nil, err
+	}
+	if err := stmt_notes.Close(); err != nil {
 		txn.Rollback()
 		return nil, err
 	}
@@ -138,8 +155,9 @@ func listTimeseriesMeasurementsSQL() string {
 					COALESCE(N.validated, 'false') AS validated,
 					COALESCE(N.annotation, '') AS annotation
 			FROM timeseries_measurement M
-			INNER JOIN timeseries_notes N
-					ON N.timeseries_id = M.timeseries_id
+			LEFT JOIN timeseries_notes N
+					ON M.timeseries_id = N.timeseries_id
+					AND M.time = N.time
 			INNER JOIN timeseries T
     			    ON T.id = M.timeseries_id
 	`

--- a/models/timeseries_measurements.go
+++ b/models/timeseries_measurements.go
@@ -134,9 +134,9 @@ func listTimeseriesMeasurementsSQL() string {
 	return `SELECT  M.timeseries_id,
 			        M.time,
 					M.value,
-					N.masked,
-					N.validated,
-					N.annotation
+					COALESCE(N.masked, 'false') AS masked,
+					COALESCE(N.validated, 'false') AS validated,
+					COALESCE(N.annotation, '') AS annotation
 			FROM timeseries_measurement M
 			INNER JOIN timeseries_notes N
 					ON N.timeseries_id = M.timeseries_id


### PR DESCRIPTION
This PR currently serves as a tracker for completion of #129. This includes the core SOW changes, as implemented in the original PR:

- [x] New columns in timeseries_measurement table
  - Mask (boolean, default false)
  - Validated (boolean, default false)
  - Annotation (varchar(400), default empty string)
- [x] Relevant tweaks to model and handler

...as well as feedback suggested by Mike Neilson:

- [x] Move new columns to their own table, double foreign-keyed against the `timeseries` database.

Its merge is contingent on merge of a corresponding PR on the [frontend](https://github.com/USACE/instrumentation-ui) (ticket number TBD).