### PR TITLE
Fix ValidateCreateInstrument to exclude deleted instruments

### DIFF
--- a/models/projects.go
+++ b/models/projects.go
@@ -224,6 +224,7 @@ func projectInstrumentNamesMap(db *sqlx.DB, projectIDs []uuid.UUID) (map[uuid.UU
 	sql := `SELECT project_id, name
 			FROM instrument
 			WHERE project_id IN (?)
+			AND NOT deleted
 			ORDER BY project_id
 			`
 	query, args, err := sqlx.In(sql, projectIDs)


### PR DESCRIPTION
Fixes bug where a user is unable to create an instrument with the same name as an instrument that has previously been "soft deleted".