### PR TITLE
Fix "formulas" endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,63 @@
-# Instrumentation API  ![Build API and Lambda Package](https://github.com/usace/instrumentation-api/workflows/Build%20API%20and%20Lambda%20Package/badge.svg)
+# Instrumentation API - Build API and Lambda Package
 
 An Application Programming Interface (API) to manage instrumentation data, built with Golang and deployed on AWS Lambda.
 
-# Documentation
+## Documentation
 
 Documentation for the API is maintained in a Markdown file held at [`docs/APIDOC.md`](./docs/APIDOC.md). A [Postman](https://www.postman.com/api-documentation-tool/) documentation and testing environment is also maintained at [`tests/postman_environment.local`](./tests/postman_environment.local.json).
 
-# How to Develop
+## How to Develop
 
-## Running a Database for Local Development
+### Quickstart - Running the API Stack Locally with Docker Compose
 
 1. Install, at a minimum, [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/). In place of these two, one can install [Docker Desktop](https://docs.docker.com/desktop/).
 
 2. Copy the `.env.example` file to `.env` (e.g., `cp .env.example .env`). This provides configuration options to Docker Compose.
 
-3. Change to the /database directory in this repository and type `docker-compose up`. This brings up two services on `localhost`
+3. Run the [./startup.sh](./startup.sh) shell script to pull the most recent changes from the current upstream branch, build, and (re)start the Docker Compose services. You can now access the application locally through Docker.
+
+### Running a Database for Local Development
+
+After starting up Docker Compose, you will find these two services (among others) on `localhost`
 
    1. A Postgres database with postgis schema installed using the Docker image [mdillon/postgis](https://hub.docker.com/r/mdillon/postgis/)
 
    2. [pgAdmin4](https://www.pgadmin.org/) using the Docker image [dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4/)
 
-   To modify the database using pgAdmin4, open a web browser and go to `http://localhost:8081`, or whichever port number is the value set to variable `PGADMIN_PORT` in `.env`.
+To modify the database using pgAdmin4, open a web browser and go to `http://localhost:8081`, or whichever port number is the value set to variable `PGADMIN_PORT` in `.env`.
 
-   Login with `Email:postgres@postgres.com` and `Password:postgres` respectively.
+Login with `Email:postgres@postgres.com` and `Password:postgres` respectively.
 
-   Create a database connection to the Postgres database by right-clicking `servers --> register --> server` in the left menu tree. Enter the following information and click `save`.
+Create a database connection to the Postgres database by right-clicking `servers --> register --> server` in the left menu tree. Enter the following information and click `save`.
 
-   **General Tab**
+#### General Tab
 
-   | Field | Value                               |
-   | ----- | ----------------------------------- |
-   | Name  | localhost (or other preferred name) |
+| Field | Value                               |
+| ----- | ----------------------------------- |
+| Name  | localhost (or other preferred name) |
 
-   **Connection Tab**
+#### Connection Tab
 
-   | Field             | Value          |
-   | ----------------- | -------------- |
-   | Host name/address | postgres       |
-   | Port              | 5432 (default) |
-   | Username          | postgres       |
-   | Password          | postgres       |
+| Field             | Value          |
+| ----------------- | -------------- |
+| Host name/address | postgres       |
+| Port              | 5432 (default) |
+| Username          | postgres       |
+| Password          | postgres       |
 
-4. Initialize the database and seed it with some data (docker-compose runs this for you)
+Initialize the database and seed it with some data (docker-compose runs this for you)
 
    Use the Query Tool in pgadmin4 and the .sql files in the database/ directory in this repository. You can find the query tool by expanding the left menu tree to `Servers --> Databases --> postgres`. Right click `postgres --> Query Tool`. From here, copy [tables.sql](database/sql/10-tables.sql) into the Query Tool and run it by pressing `f5`. Note: to only run a portion of the SQL you've copied, you can highlight the section you want to run before hitting `f5`.
 
-## Running the GO API for Local Development
+### Running the GO API for Local Development
 
 Either of these options starts the API at `localhost:$API_PORT`, where `$API_PORT` is the variable set in your project's `.env` file. The API uses JSON Web tokens (JWT) for authorization by default.  To disable JWT for testing or development, you can set the environment variable `JWT_DISABLED=TRUE`.
 
-**With Visual Studio Code Debugger**
+### With Visual Studio Code Debugger
 
 You can use the launch.json file in this repository in lieu of `go run main.go` to run the API in the VSCode debugger.  This takes care of the required environment variables to connect to the database.
 
-**Without Visual Studio Code Debugger**
+### Without Visual Studio Code Debugger
 
 Set the following environment variables and type `go run main.go` from the top level of this repository.
 
@@ -75,12 +79,7 @@ In both cases, the Postman environment regression tests are run, then output. If
 
 ## Running the Swagger UI to access API documentation locally
 
-An API Document conforming to the OpenAPI 3.0.0 specification is generated from the most recent Postman Collection saved to [`tests/instrumentation-regression.postman_collection.json`](./tests/instrumentation-regression.postman_collection.json). When the collection file is modified and overwritten, an updated apidoc.json will be automatically created by a `swagger_init` docker service at [docs/swagger/apidoc.json](./docs/swagger/apidoc.json).
-
-To start the Swagger UI server and sync the apidoc.json with the Postman Collection, run:
-```sh
-docker compose -f docker-compose.swagger.yml up -d
-```
+An API Document conforming to the OpenAPI 3.0.0 specification is generated from the most recent Postman Collection saved to [`tests/instrumentation-regression.postman_collection.json`](./tests/instrumentation-regression.postman_collection.json). When the collection file is modified and overwritten, an updated apidoc.json will be automatically created by a `swagger_init` docker service at [docs/swagger/apidoc.json](./docs/swagger/apidoc.json). To start the Swagger UI server and sync the apidoc.json with the Postman Collection, run `docker compose -f docker-compose.swagger.yml up -d`. This command is also executed in [./startup.sh](./startup.sh).
 
 Note:
 
@@ -90,9 +89,9 @@ Note:
 
 - Swagger UI configuration can be adjusted with [docs/swagger/swagger-config.json](./docs/swagger/swagger-config.json). See [swagger-ui/docs/usage/configuration.md](https://github.com/swagger-api/swagger-ui/blob/0b8de2c1796e67602bcbbc6d35c99cb167acf388/docs/usage/configuration.md) for the full list of configuration options.
 
-# How To Deploy
+## How To Deploy
 
-## Postgres Database on AWS Relational Database Service (RDS)
+### Postgres Database on AWS Relational Database Service (RDS)
 
 Database should be initialized with the following SQL files in the order listed:
 
@@ -104,7 +103,7 @@ Database should be initialized with the following SQL files in the order listed:
 
    Note: Change 'password' in roles.sql to a real password for the `instrumentation_user` account.
 
-# How to Update
+## How to Update
 
 Updating an instance of `instrumentation-api` is trivially completed by rebuilding the Docker container used by it, then restarting the service.
 

--- a/database/snippets/migration_40_calculation_ids.sql
+++ b/database/snippets/migration_40_calculation_ids.sql
@@ -191,6 +191,10 @@ ALTER TABLE instrument
     DROP COLUMN IF EXISTS formula_parameter_id,
     DROP COLUMN IF EXISTS formula_unit_id;
 
+ALTER TABLE calculation
+    ALTER COLUMN parameter_id SET DEFAULT '2b7f96e1-820f-4f61-ba8f-861640af6232',
+    ALTER COLUMN unit_id SET DEFAULT '4a999277-4cf5-4282-93ce-23b33c65e2c8';
+
 GRANT SELECT ON
     v_instrument,
     v_timeseries,

--- a/docker-compose.swagger.yml
+++ b/docker-compose.swagger.yml
@@ -1,5 +1,9 @@
 version: '3'
 
+networks:
+  default:
+    name: ecw-api_default
+    
 services:
   swagger_init:
     image: node:current-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
   api:
     build:
       context: ./
+      labels:
+        - com.host.description=instrumentation-api
     restart: always
     environment:
       # NOTE: AWS_ Variables provided by execution role in deployed version

--- a/docs/swagger/apidoc.json
+++ b/docs/swagger/apidoc.json
@@ -29,7 +29,7 @@
             "name": "Profiles"
         },
         {
-            "name": "ProjectMembership"
+            "name": "Project Membership"
         },
         {
             "name": "Instruments"
@@ -149,7 +149,7 @@
         "/projects/{project_id}/members": {
             "get": {
                 "tags": [
-                    "ProjectMembership"
+                    "Project Membership"
                 ],
                 "summary": "ListProjectMembers",
                 "parameters": [
@@ -177,7 +177,7 @@
         "/projects/{project_id}/members/{member_id}/roles/{role_id}": {
             "delete": {
                 "tags": [
-                    "ProjectMembership"
+                    "Project Membership"
                 ],
                 "summary": "RemoveProjectMemberRole",
                 "parameters": [
@@ -223,7 +223,7 @@
             },
             "post": {
                 "tags": [
-                    "ProjectMembership"
+                    "Project Membership"
                 ],
                 "summary": "AddProjectMemberRole",
                 "requestBody": {

--- a/docs/swagger/apidoc.json
+++ b/docs/swagger/apidoc.json
@@ -73,7 +73,7 @@
             "name": "Collection Groups"
         },
         {
-            "name": "Calculations"
+            "name": "Formulas"
         }
     ],
     "paths": {
@@ -2963,21 +2963,20 @@
                 }
             }
         },
-        "/calculations/{instrument_id}": {
+        "/formulas": {
             "get": {
                 "tags": [
-                    "Calculations"
+                    "Formulas"
                 ],
-                "summary": "GetCalculation",
+                "summary": "GetInstrumentFormulas",
                 "parameters": [
                     {
                         "name": "instrument_id",
-                        "in": "path",
+                        "in": "query",
                         "schema": {
                             "type": "string"
                         },
-                        "required": true,
-                        "description": "Instrument to fetch calculation formulas for.",
+                        "description": "Instrument uuid",
                         "example": "a7540f69-c41e-43b3-b655-6e44097edb7e"
                     }
                 ],
@@ -2989,14 +2988,12 @@
                         }
                     }
                 }
-            }
-        },
-        "/calculations": {
+            },
             "post": {
                 "tags": [
-                    "Calculations"
+                    "Formulas"
                 ],
-                "summary": "CreateCalculation",
+                "summary": "CreateFormula",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -3007,35 +3004,8 @@
                                     "parameter_id": "068b59b0-aafb-4c98-ae4b-ed0365a6fbac",
                                     "unit_id": "f777f2e2-5e32-424e-a1ca-19d16cd8abce",
                                     "slug": "test_calculation",
-                                    "name": "test calculation",
-                                    "contents": "a + b"
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful response",
-                        "content": {
-                            "application/json": {}
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Calculations"
-                ],
-                "summary": "UpdateCalculation",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "example": {
-                                    "id": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
-                                    "formula_name": "NEW NAME"
+                                    "formula_name": "test calculation",
+                                    "formula": "a + b"
                                 }
                             }
                         }
@@ -3051,21 +3021,61 @@
                 }
             }
         },
-        "/calculations/{calculation_id}": {
-            "delete": {
+        "/formulas/{formula_id}": {
+            "put": {
                 "tags": [
-                    "Calculations"
+                    "Formulas"
                 ],
-                "summary": "DeleteCalculation",
+                "summary": "UpdateFormula",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "example": {
+                                    "id": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
+                                    "formula_name": "NEW NAME",
+                                    "formula": "c + d"
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
                     {
-                        "name": "calculation_id",
+                        "name": "formula_id",
                         "in": "path",
                         "schema": {
                             "type": "string"
                         },
                         "required": true,
-                        "description": "Calculation to remove.",
+                        "description": "Formula uuid",
+                        "example": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Formulas"
+                ],
+                "summary": "DeleteFormula",
+                "parameters": [
+                    {
+                        "name": "formula_id",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "description": "Formula uuid",
                         "example": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984"
                     }
                 ],

--- a/docs/swagger/apidoc.json
+++ b/docs/swagger/apidoc.json
@@ -44,8 +44,7 @@
             "name": "Plot Configurations"
         },
         {
-            "name": "Projects",
-            "description": "Project Endpoint Tests"
+            "name": "Projects"
         },
         {
             "name": "Timeseries"

--- a/handlers/calculations.go
+++ b/handlers/calculations.go
@@ -38,19 +38,29 @@ func ComputedTimeseries(db *sqlx.DB) echo.HandlerFunc {
 	}
 }
 
-// GetCalculations retrieves an array of `Calculation`s associated with a particular
+// GetInstrumentCalculations retrieves an array of `Calculation`s associated with a particular
 // instrument ID.
 //
-// Parameters:
+// Query Parameters:
 // - `instrument_id`: string
-func GetCalculations(db *sqlx.DB) echo.HandlerFunc {
+func GetInstrumentCalculations(db *sqlx.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		instrumentID, err := uuid.Parse(c.Param("instrument_id"))
+		param := c.QueryParam("instrument_id")
+
+		if param == "" {
+			return c.String(
+				http.StatusBadRequest,
+				"Missing query parameter 'instrument_id'",
+			)
+		}
+
+		// Instrument ID
+		instrumentID, err := uuid.Parse(param)
 		if err != nil {
 			return c.String(http.StatusBadRequest, err.Error())
 		}
 
-		formulas, err := models.GetCalculations(db, &models.Instrument{ID: instrumentID})
+		formulas, err := models.GetInstrumentCalculations(db, &models.Instrument{ID: instrumentID})
 		if err != nil {
 			return c.String(http.StatusInternalServerError, err.Error())
 		}
@@ -58,10 +68,10 @@ func GetCalculations(db *sqlx.DB) echo.HandlerFunc {
 	}
 }
 
-// CreateCalculation for a given instrument.
+// CreateCalculation creates a calculation.
 //
 // Parameters:
-// - Body should be a computation model in the database.
+// - Body should be a calculation model in the database.
 func CreateCalculation(db *sqlx.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var formula models.Calculation
@@ -78,32 +88,46 @@ func CreateCalculation(db *sqlx.DB) echo.HandlerFunc {
 	}
 }
 
-// UpdateCalculation for a given instrument.
+// UpdateCalculation updates a calculation.
+//
+// Paramaters:
+// - `formula_id` should refer to the ID of a calculation in the database.
 func UpdateCalculation(db *sqlx.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		var formula models.Calculation
-		if err := c.Bind(&formula); err != nil {
-			return c.String(http.StatusBadRequest, err.Error())
-		}
-		if err := models.UpdateCalculation(db, &formula); err != nil {
-			return c.String(http.StatusInternalServerError, err.Error())
-		}
-		return c.JSON(http.StatusOK, &formula)
-	}
-}
-
-// DeleteCalculation for a given instrument.
-//
-// Parameters:
-// - `computation_id` should refer to the ID of a computation in the database.
-func DeleteCalculation(db *sqlx.DB) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		computationID, err := uuid.Parse(c.Param("computation_id"))
+		calculationID, err := uuid.Parse(c.Param("formula_id"))
 		if err != nil {
 			return c.String(http.StatusBadRequest, err.Error())
 		}
 
-		if err := models.DeleteCalculation(db, computationID); err != nil {
+		var calculation models.Calculation
+		if err := c.Bind(&calculation); err != nil {
+			return c.String(http.StatusBadRequest, err.Error())
+		}
+
+		// Compare Calculation ID from Route Params to Calculation ID from Payload
+		if calculationID != calculation.ID {
+			return c.JSON(http.StatusBadRequest, models.DefaultMessageBadRequest)
+		}
+
+		if err := models.UpdateCalculation(db, &calculation); err != nil {
+			return c.String(http.StatusInternalServerError, err.Error())
+		}
+		return c.JSON(http.StatusOK, &calculation)
+	}
+}
+
+// DeleteCalculation deletes a calculation.
+//
+// Parameters:
+// - `formula_id` should refer to the ID of a calculation in the database.
+func DeleteCalculation(db *sqlx.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		calculationID, err := uuid.Parse(c.Param("formula_id"))
+		if err != nil {
+			return c.String(http.StatusBadRequest, err.Error())
+		}
+
+		if err := models.DeleteCalculation(db, calculationID); err != nil {
 			return c.String(http.StatusInternalServerError, err.Error())
 		}
 		return c.NoContent(http.StatusOK)

--- a/main.go
+++ b/main.go
@@ -290,11 +290,11 @@ func main() {
 	private.PUT("/projects/:project_id/plot_configurations/:plot_configuration_id", handlers.UpdatePlotConfiguration(db))
 	private.DELETE("/projects/:project_id/plot_configurations/:plot_configuration_id", handlers.DeletePlotConfiguration(db))
 
-	// Formulas and calculations
-	private.POST("/calculations", handlers.CreateCalculation(db))
-	private.PUT("/calculations", handlers.UpdateCalculation(db))
-	public.GET("/calculations/:instrument_id", handlers.GetCalculations(db))
-	private.DELETE("/calculations/:computation_id", handlers.DeleteCalculation(db))
+	// Formulas == Calculations
+	public.GET("/formulas", handlers.GetInstrumentCalculations(db))
+	private.POST("/formulas", handlers.CreateCalculation(db))
+	private.PUT("/formulas/:formula_id", handlers.UpdateCalculation(db))
+	private.DELETE("/formulas/:formula_id", handlers.DeleteCalculation(db))
 
 	// Misc
 	public.GET("/domains", handlers.GetDomains(db))

--- a/models/calculations.go
+++ b/models/calculations.go
@@ -114,8 +114,8 @@ func CalculationsFactory(rows *sqlx.Rows) ([]Calculation, error) {
 	return formulas, nil
 }
 
-// GetCalculations returns all formulas associated to a given instrument ID.
-func GetCalculations(db *sqlx.DB, instrument *Instrument) ([]Calculation, error) {
+// GetInstrumentCalculations returns all formulas associated to a given instrument ID.
+func GetInstrumentCalculations(db *sqlx.DB, instrument *Instrument) ([]Calculation, error) {
 
 	rows, err := db.Queryx(listCalculationsSQL+" WHERE instrument_id = $1", instrument.ID)
 	if err != nil {
@@ -395,7 +395,7 @@ func ComputedTimeseries(db *sqlx.DB, instrumentIDs []uuid.UUID, tw *TimeWindow, 
 
 	tt := make([]DBTimeseries, 0)
 	sql := `
-	-- Get Timeseries and Dependencies for Computations
+	-- Get Timeseries and Dependencies for Calculations
 	-- timeseries required based on requested instrument
 	WITH requested_instruments AS (
 		SELECT id
@@ -509,7 +509,7 @@ func ComputedTimeseries(db *sqlx.DB, instrumentIDs []uuid.UUID, tw *TimeWindow, 
 	variableMap := make(map[time.Time]map[string]interface{})
 
 	// todo: Optimization - do not need to regularize all timeseries
-	// only need to regularize those that will be used as computation dependencies
+	// only need to regularize those that will be used as calculation dependencies
 	for _, ts := range tt2 {
 		tsReg, err := ts.RegularizeCarryForward(*tw, *interval)
 		if err != nil {
@@ -528,8 +528,8 @@ func ComputedTimeseries(db *sqlx.DB, instrumentIDs []uuid.UUID, tw *TimeWindow, 
 			continue
 		}
 
-		// Computations
-		// It is known that all stored timeseries have been added to the Map and computations
+		// Calculations
+		// It is known that all stored timeseries have been added to the Map and calculations
 		// can now be run because alculated timeseries (identified by .IsComputed)
 		// are returned from the database last in the query using ORDER BY is_computed
 		err = ts.Calculate(variableMap)
@@ -548,7 +548,7 @@ func ComputedInclinometerTimeseries(db *sqlx.DB, instrumentIDs []uuid.UUID, tw *
 
 	tt := make([]DBTimeseries, 0)
 	sql := `
-	-- Get Timeseries and Dependencies for Computations
+	-- Get Timeseries and Dependencies for Calculations
 	-- timeseries required based on requested instrument
 	WITH requested_instruments AS (
 		SELECT id

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Script to conveniently git pull and rebuild images and (re)start docker stack
+git pull;
+
+docker compose down;
+docker compose -f ./docker-compose.swagger.yml down;
+
+docker builder prune --force --filter "label=instrumentation-api";
+
+docker compose up -d --build;
+# suppress incorrect warning of orphan containers created in above line
+COMPOSE_IGNORE_ORPHANS=1 docker compose -f ./docker-compose.swagger.yml up -d;

--- a/tests/instrumentation-regression.postman_collection.json
+++ b/tests/instrumentation-regression.postman_collection.json
@@ -140,7 +140,7 @@
 			]
 		},
 		{
-			"name": "ProjectMembership",
+			"name": "Project Membership",
 			"item": [
 				{
 					"name": "ListProjectMembers",

--- a/tests/instrumentation-regression.postman_collection.json
+++ b/tests/instrumentation-regression.postman_collection.json
@@ -3113,7 +3113,6 @@
 					"response": []
 				}
 			],
-			"description": "Project Endpoint Tests"
 		},
 		{
 			"name": "Timeseries",

--- a/tests/instrumentation-regression.postman_collection.json
+++ b/tests/instrumentation-regression.postman_collection.json
@@ -3112,7 +3112,7 @@
 					},
 					"response": []
 				}
-			],
+			]
 		},
 		{
 			"name": "Timeseries",

--- a/tests/instrumentation-regression.postman_collection.json
+++ b/tests/instrumentation-regression.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9c819887-188d-4cfe-999d-970febc97fea",
+		"_postman_id": "e47472c2-8049-4b8d-a9be-c17f6911b242",
 		"name": "instrumentation-regression",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -5314,10 +5314,10 @@
 			]
 		},
 		{
-			"name": "Calculations",
+			"name": "Formulas",
 			"item": [
 				{
-					"name": "GetCalculation",
+					"name": "GetInstrumentFormulas",
 					"event": [
 						{
 							"listen": "test",
@@ -5336,8 +5336,8 @@
 									"            \"parameter_id\": { \"type\": \"string\" },\r",
 									"            \"unit_id\": { \"type\": \"string\" },\r",
 									"            \"slug\": { \"type\": \"string\" },\r",
-									"            \"name\": { \"type\": \"string\" },\r",
-									"            \"contents\": { \"type\": \"string\" },\r",
+									"            \"formula_name\": { \"type\": \"string\" },\r",
+									"            \"formula\": { \"type\": \"string\" },\r",
 									"        },\r",
 									"        \"required\": [\r",
 									"            \"id\",\r",
@@ -5345,8 +5345,8 @@
 									"            \"parameter_id\",\r",
 									"            \"unit_id\",\r",
 									"            \"slug\",\r",
-									"            \"name\",\r",
-									"            \"contents\",\r",
+									"            \"formula_name\",\r",
+									"            \"formula\",\r",
 									"        ]\r",
 									"    });\r",
 									"});\r",
@@ -5360,19 +5360,18 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{base_url}}/calculations/:instrument_id",
+							"raw": "{{base_url}}/formulas?instrument_id=a7540f69-c41e-43b3-b655-6e44097edb7e",
 							"host": [
 								"{{base_url}}"
 							],
 							"path": [
-								"calculations",
-								":instrument_id"
+								"formulas"
 							],
-							"variable": [
+							"query": [
 								{
 									"key": "instrument_id",
 									"value": "a7540f69-c41e-43b3-b655-6e44097edb7e",
-									"description": "Instrument to fetch calculation formulas for."
+									"description": "Instrument uuid"
 								}
 							]
 						}
@@ -5380,7 +5379,7 @@
 					"response": []
 				},
 				{
-					"name": "CreateCalculation",
+					"name": "CreateFormula",
 					"event": [
 						{
 							"listen": "test",
@@ -5412,7 +5411,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"instrument_id\": \"a7540f69-c41e-43b3-b655-6e44097edb7e\",\r\n    \"parameter_id\": \"068b59b0-aafb-4c98-ae4b-ed0365a6fbac\",\r\n    \"unit_id\": \"f777f2e2-5e32-424e-a1ca-19d16cd8abce\",\r\n    \"slug\": \"test_calculation\",\r\n    \"name\": \"test calculation\",\r\n    \"contents\": \"a + b\"\r\n}",
+							"raw": "{\r\n    \"instrument_id\": \"a7540f69-c41e-43b3-b655-6e44097edb7e\",\r\n    \"parameter_id\": \"068b59b0-aafb-4c98-ae4b-ed0365a6fbac\",\r\n    \"unit_id\": \"f777f2e2-5e32-424e-a1ca-19d16cd8abce\",\r\n    \"slug\": \"test_calculation\",\r\n    \"formula_name\": \"test calculation\",\r\n    \"formula\": \"a + b\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5420,19 +5419,19 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/calculations",
+							"raw": "{{base_url}}/formulas",
 							"host": [
 								"{{base_url}}"
 							],
 							"path": [
-								"calculations"
+								"formulas"
 							]
 						}
 					},
 					"response": []
 				},
 				{
-					"name": "UpdateCalculation",
+					"name": "UpdateFormula",
 					"event": [
 						{
 							"listen": "test",
@@ -5463,7 +5462,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"id\": \"5b6f4f37-7755-4cf9-bd02-94f1e9bc5984\",\r\n    \"formula_name\": \"NEW NAME\"\r\n}",
+							"raw": "{\r\n    \"id\": \"5b6f4f37-7755-4cf9-bd02-94f1e9bc5984\",\r\n    \"formula_name\": \"NEW NAME\",\r\n    \"formula\": \"c + d\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5471,19 +5470,27 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/calculations",
+							"raw": "{{base_url}}/formulas/:formula_id",
 							"host": [
 								"{{base_url}}"
 							],
 							"path": [
-								"calculations"
+								"formulas",
+								":formula_id"
+							],
+							"variable": [
+								{
+									"key": "formula_id",
+									"value": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
+									"description": "Formula uuid"
+								}
 							]
 						}
 					},
 					"response": []
 				},
 				{
-					"name": "DeleteCalculation",
+					"name": "DeleteFormula",
 					"event": [
 						{
 							"listen": "test",
@@ -5503,19 +5510,19 @@
 						"method": "DELETE",
 						"header": [],
 						"url": {
-							"raw": "{{base_url}}/calculations/:calculation_id",
+							"raw": "{{base_url}}/formulas/:formula_id",
 							"host": [
 								"{{base_url}}"
 							],
 							"path": [
-								"calculations",
-								":calculation_id"
+								"formulas",
+								":formula_id"
 							],
 							"variable": [
 								{
-									"key": "calculation_id",
+									"key": "formula_id",
 									"value": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
-									"description": "Calculation to remove."
+									"description": "Formula uuid"
 								}
 							]
 						}


### PR DESCRIPTION
This PR includes the following changes relates to the `/formulas` endpoints (previously `calculations`):

- [x] Edit the calculation POST payload, the values should bind to the same ones that get sent back
- [x] Add ability to edit parameters other name formula name in PUT request
- [x] Add calculation id to url in PUT request
- [x] ~~Remove the~~ parameter id and slug from the calculation/formula payload
  - Reinstated defaults for parameter_id and unit_id
  - Proper slug generation
- [x] GET request for when instrument does not have any formulas throws error, should return empty array
- [x] **Rename all references to computation or calculation to formula in client facing API**
- [x] Change GET request `instrument_id` path parameter to query parameter
  - e.g. `/formulas/{instrument_id}` --> `/formulas?instrument_id=___`
- [x] Create script to easily pull most recent branch and restart/build docker compose stack
