### PR TITLE
Add capability to edit time series measurements

### DIFF
--- a/docs/swagger/apidoc.json
+++ b/docs/swagger/apidoc.json
@@ -2083,6 +2083,7 @@
                         "schema": {
                             "type": "string"
                         },
+                        "description": "Default timestamp 7 days prior to now",
                         "example": "1900-01-01T00:00:00.00Z"
                     },
                     {
@@ -2091,6 +2092,7 @@
                         "schema": {
                             "type": "string"
                         },
+                        "description": "Default timestamp now",
                         "example": "2021-01-01T00:00:00.00Z"
                     },
                     {

--- a/docs/swagger/apidoc.json
+++ b/docs/swagger/apidoc.json
@@ -2043,6 +2043,75 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "tags": [
+                    "Timeseries"
+                ],
+                "summary": "UpdateTimeseriesMeasurements",
+                "description": "Overwrites measurements with the supplied payload within a time window (> after, < before)",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "example": {
+                                    "timeseries_id": "869465fc-dc1e-445e-81f4-9979b5fadda9",
+                                    "items": [
+                                        {
+                                            "time": "2020-01-23T00:00:00Z",
+                                            "value": 130.05,
+                                            "masked": true,
+                                            "validated": true,
+                                            "annotation": "test"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "1900-01-01T00:00:00.00Z"
+                    },
+                    {
+                        "name": "before",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "2021-01-01T00:00:00.00Z"
+                    },
+                    {
+                        "name": "project_id",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true,
+                        "description": "Project uuid",
+                        "example": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
             }
         },
         "/projects/{project_id}/instruments/{instrument_id}/constants": {

--- a/handlers/timeseries measurements.go
+++ b/handlers/timeseries measurements.go
@@ -131,7 +131,8 @@ func UpdateTimeseriesMeasurements(db *sqlx.DB) echo.HandlerFunc {
 		a, b := c.QueryParam("after"), c.QueryParam("before")
 		// If after or before are not provided return last 7 days of data from current time
 		if a == "" || b == "" {
-			return c.JSON(http.StatusBadRequest, "Did not supply required query parameters 'after' and 'before'")
+			tw.Before = time.Now()
+			tw.After = tw.Before.AddDate(0, 0, -7)
 		} else {
 			// Attempt to parse query param "after"
 			tA, err := time.Parse(time.RFC3339, a)

--- a/handlers/timeseries measurements.go
+++ b/handlers/timeseries measurements.go
@@ -156,7 +156,7 @@ func UpdateTimeseriesMeasurements(db *sqlx.DB) echo.HandlerFunc {
 		if err != nil {
 			return c.JSON(http.StatusBadRequest, err)
 		}
-		return c.JSON(http.StatusCreated, stored)
+		return c.JSON(http.StatusOK, stored)
 	}
 }
 

--- a/handlers/timeseries measurements.go
+++ b/handlers/timeseries measurements.go
@@ -122,6 +122,44 @@ func CreateOrUpdateTimeseriesMeasurements(db *sqlx.DB) echo.HandlerFunc {
 	}
 }
 
+// UpdateTimeseriesMeasurements Overwrites measurements with the supplied payload
+// within a TimeWindow (> after, < before)
+func UpdateTimeseriesMeasurements(db *sqlx.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		// Time Window
+		var tw timeseries.TimeWindow
+		a, b := c.QueryParam("after"), c.QueryParam("before")
+		// If after or before are not provided return last 7 days of data from current time
+		if a == "" || b == "" {
+			return c.JSON(http.StatusBadRequest, "Did not supply required query parameters 'after' and 'before'")
+		} else {
+			// Attempt to parse query param "after"
+			tA, err := time.Parse(time.RFC3339, a)
+			if err != nil {
+				return c.JSON(http.StatusBadRequest, err)
+			}
+			tw.After = tA
+			// Attempt to parse query param "before"
+			tB, err := time.Parse(time.RFC3339, b)
+			if err != nil {
+				return c.JSON(http.StatusBadRequest, err)
+			}
+			tw.Before = tB
+		}
+
+		var mcc models.TimeseriesMeasurementCollectionCollection
+		if err := c.Bind(&mcc); err != nil {
+			return c.JSON(http.StatusBadRequest, err)
+		}
+		// Put timeseries measurments
+		stored, err := models.UpdateTimeseriesMeasurements(db, mcc.Items, &tw)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, err)
+		}
+		return c.JSON(http.StatusCreated, stored)
+	}
+}
+
 // DeleteTimeserieMeasurements deletes a single timeseries measurement
 func DeleteTimeserieMeasurements(db *sqlx.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/main.go
+++ b/main.go
@@ -263,6 +263,7 @@ func main() {
 	public.GET("/instruments/:instrument_id/timeseries/:timeseries_id", handlers.GetTimeseries(db))
 	public.GET("/timeseries/:timeseries_id/measurements", handlers.ListTimeseriesMeasurements(db))
 	private.DELETE("/timeseries/:timeseries_id/measurements", handlers.DeleteTimeserieMeasurements(db))
+	private.PUT("/projects/:project_id/timeseries_measurements", handlers.UpdateTimeseriesMeasurements(db))
 	public.GET("/timeseries/:timeseries_id/inclinometer_measurements", handlers.ListInclinometerMeasurements(db))
 	private.DELETE("/timeseries/:timeseries_id/inclinometer_measurements", handlers.DeleteInclinometerMeasurements(db))
 	public.GET("/instruments/:instrument_id/timeseries/:timeseries_id/measurements", handlers.ListTimeseriesMeasurements(db))

--- a/tests/instrumentation-regression.postman_collection.json
+++ b/tests/instrumentation-regression.postman_collection.json
@@ -3619,6 +3619,77 @@
 					"response": []
 				},
 				{
+					"name": "UpdateTimeseriesMeasurements",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// status code is 200",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt_existing_admin}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"timeseries_id\": \"869465fc-dc1e-445e-81f4-9979b5fadda9\",\n    \"items\": [\n        {\n            \"time\": \"2020-01-23T00:00:00Z\",\n            \"value\": 130.05,\n            \"masked\": true,\n            \"validated\": true,\n            \"annotation\": \"test\"\n        }\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/projects/:project_id/timeseries_measurements?after=1900-01-01T00:00:00.00Z&before=2021-01-01T00:00:00.00Z",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"projects",
+								":project_id",
+								"timeseries_measurements"
+							],
+							"query": [
+								{
+									"key": "after",
+									"value": "1900-01-01T00:00:00.00Z"
+								},
+								{
+									"key": "before",
+									"value": "2021-01-01T00:00:00.00Z"
+								}
+							],
+							"variable": [
+								{
+									"key": "project_id",
+									"value": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
+									"description": "Project uuid"
+								}
+							]
+						},
+						"description": "Overwrites measurements with the supplied payload within a time window (> after, < before)"
+					},
+					"response": []
+				},
+				{
 					"name": "UpdateTimeseries",
 					"event": [
 						{

--- a/tests/instrumentation-regression.postman_collection.json
+++ b/tests/instrumentation-regression.postman_collection.json
@@ -3670,11 +3670,13 @@
 							"query": [
 								{
 									"key": "after",
-									"value": "1900-01-01T00:00:00.00Z"
+									"value": "1900-01-01T00:00:00.00Z",
+									"description": "Default timestamp 7 days prior to now"
 								},
 								{
 									"key": "before",
-									"value": "2021-01-01T00:00:00.00Z"
+									"value": "2021-01-01T00:00:00.00Z",
+									"description": "Default timestamp now"
 								}
 							],
 							"variable": [


### PR DESCRIPTION
Add capability to edit time series measurements within a time window supplied as query parameters (after, before). Default query param values mirror those in GET timeseries_measurement endpoint (past week from the current date).