### PR TITLE
v1.5.1 Bug Fixes

### DIFF
--- a/handlers/timeseries_measurements.go
+++ b/handlers/timeseries_measurements.go
@@ -35,7 +35,6 @@ func allTimeseriesBelongToProject(db *sqlx.DB, mcc *models.TimeseriesMeasurement
 	return true, nil
 }
 
-
 // ListTimeseriesMeasurements TODO (possible optimization):
 // Due to the amount of repeated data for each time entry (and the inherent size of those payloads)
 // it is possible to decreate repetition for some data points for regularized computed intervals,

--- a/models/timeseries_measurements.go
+++ b/models/timeseries_measurements.go
@@ -45,7 +45,7 @@ func (cc *TimeseriesMeasurementCollectionCollection) UnmarshalJSON(b []byte) err
 	return nil
 }
 
-// ListTimeseriesMeasurements returns a timeseries with slice of timeseries measurements populated
+// ListTimeseriesMeasurements returns a stored timeseries with slice of timeseries measurements populated
 func ListTimeseriesMeasurements(db *sqlx.DB, timeseriesID *uuid.UUID, tw *ts.TimeWindow) (*ts.MeasurementCollection, error) {
 
 	mc := ts.MeasurementCollection{TimeseriesID: *timeseriesID}
@@ -56,6 +56,9 @@ func ListTimeseriesMeasurements(db *sqlx.DB, timeseriesID *uuid.UUID, tw *ts.Tim
 		timeseriesID, tw.After, tw.Before,
 	); err != nil {
 		return nil, err
+	}
+	if mc.Items == nil {
+		mc.Items = make([]ts.Measurement, 0)
 	}
 
 	return &mc, nil
@@ -192,6 +195,7 @@ func UpdateTimeseriesMeasurements(db *sqlx.DB, mc []ts.MeasurementCollection, tw
 	return mc, nil
 }
 
+// Stored timeseries
 func listTimeseriesMeasurementsSQL() string {
 	return `SELECT  M.timeseries_id,
 			        M.time,


### PR DESCRIPTION
## Bug fixes:

#### Formulas
- If no formula name provided, "new-formula" slug will be set and name will be set to match slug
- Slug updated when formula name updated

#### (Stored) Timeseries Measurements
- When querying stored time series measurements, `db.Select` would return null if no rows found. Now returns empty slice.
