### PR TITLE
Fix error when attempting to delete plot config

### DIFF
--- a/database/snippets/migration_42_plot_config_cascade_delete.sql
+++ b/database/snippets/migration_42_plot_config_cascade_delete.sql
@@ -1,0 +1,14 @@
+-- fix error when attempting to delete plot config; foreign key constraint
+
+set search_path = "$user", midas, public, topology;
+
+BEGIN;
+
+ALTER TABLE IF EXISTS midas.plot_configuration_settings
+DROP CONSTRAINT plot_configuration_settings_id_fkey,
+ADD CONSTRAINT plot_configuration_settings_id_fkey
+	FOREIGN KEY (id)
+    REFERENCES midas.plot_configuration (id) MATCH SIMPLE
+	ON DELETE CASCADE;
+	
+COMMIT;

--- a/database/sql/10-tables.sql
+++ b/database/sql/10-tables.sql
@@ -378,7 +378,7 @@ CREATE TABLE IF NOT EXISTS plot_configuration_settings (
     show_nonvalidated BOOLEAN DEFAULT 'false',
     show_comments BOOLEAN DEFAULT 'false',
 
-    FOREIGN KEY (id) REFERENCES plot_configuration (id)
+    FOREIGN KEY (id) REFERENCES plot_configuration (id) ON DELETE CASCADE
 );
 
 


### PR DESCRIPTION
Run `database/snippets/migration_42_plot_config_cascade_delete.sql` on the production database.
