### PR TITLE
Fix interpolation when buffer head is at last index

### DIFF
--- a/models/computed_timeseries.go
+++ b/models/computed_timeseries.go
@@ -181,7 +181,7 @@ func (ts Timeseries) AggregateInterpolate(w timeseries.TimeWindow, allTimes []ti
 		}
 
 		// Time allTimes buffer caught up with working array index, add measurement and advance working index
-		if tm == a[wkIdx].Time || wkIdx == lastIdx {
+		if tm == a[wkIdx].Time {
 			interpolated = append(interpolated, Measurement{tm, a[wkIdx].Value})
 			wkIdx += 1
 			continue


### PR DESCRIPTION
Fixes issue where interpolation process would stop when buffer is at last index position. Apparent when one dataset has fresher data than the other in the formula.