### PR TITLE
handle "NAN" and "INF" edge cases: ignore vals

### DIFF
--- a/api/handlers/datalogger_telemetry.go
+++ b/api/handlers/datalogger_telemetry.go
@@ -155,7 +155,7 @@ func getCR6Handler(db *sqlx.DB, dl *models.DataLogger, rawJSON *[]byte) echo.Han
 					delete(eqtFields, f.Name)
 					continue
 				}
-				items[j] = timeseries.Measurement{TimeseriesID: *row.TimeseriesID, Time: t, Value: d.Vals[i]}
+				items[j] = timeseries.Measurement{TimeseriesID: *row.TimeseriesID, Time: t, Value: float64(d.Vals[i])}
 			}
 
 			mcs[i] = timeseries.MeasurementCollection{TimeseriesID: *row.TimeseriesID, Items: items}

--- a/api/models/datalogger_parsers.go
+++ b/api/models/datalogger_parsers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"log"
+	"math"
 	"os"
 )
 
@@ -13,9 +14,9 @@ type DataLoggerPayload struct {
 }
 
 type Datum struct {
-	Time string              `json:"time"`
-	No   int64               `json:"no"`
-	Vals []FloatIgnoreNanInf `json:"vals"`
+	Time string        `json:"time"`
+	No   int64         `json:"no"`
+	Vals []FloatNanInf `json:"vals"`
 }
 
 type Head struct {
@@ -42,18 +43,20 @@ type Field struct {
 	Settable bool   `json:"settable"`
 }
 
-type FloatIgnoreNanInf float64
+type FloatNanInf float64
 
-func (j *FloatIgnoreNanInf) UnsmarshalJSON(v []byte) error {
+func (j *FloatNanInf) UnmarshalJSON(v []byte) error {
 	switch string(v) {
-	case "NAN", "INF":
-		// ignored
+	case `"NAN"`:
+		*j = FloatNanInf(math.NaN())
+	case `"INF"`:
+		*j = FloatNanInf(math.Inf(1))
 	default:
 		var fv float64
 		if err := json.Unmarshal(v, &fv); err != nil {
 			return err
 		}
-		*j = FloatIgnoreNanInf(fv)
+		*j = FloatNanInf(fv)
 	}
 	return nil
 }

--- a/api/models/datalogger_parsers.go
+++ b/api/models/datalogger_parsers.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"log"
 	"os"
 )
@@ -12,9 +13,9 @@ type DataLoggerPayload struct {
 }
 
 type Datum struct {
-	Time string    `json:"time"`
-	No   int64     `json:"no"`
-	Vals []float64 `json:"vals"`
+	Time string              `json:"time"`
+	No   int64               `json:"no"`
+	Vals []FloatIgnoreNanInf `json:"vals"`
 }
 
 type Head struct {
@@ -39,6 +40,22 @@ type Field struct {
 	Units    string `json:"units"`
 	Process  string `json:"process"`
 	Settable bool   `json:"settable"`
+}
+
+type FloatIgnoreNanInf float64
+
+func (j *FloatIgnoreNanInf) UnsmarshalJSON(v []byte) error {
+	switch string(v) {
+	case "NAN", "INF":
+		// ignored
+	default:
+		var fv float64
+		if err := json.Unmarshal(v, &fv); err != nil {
+			return err
+		}
+		*j = FloatIgnoreNanInf(fv)
+	}
+	return nil
 }
 
 // ParseTOA5 parses a Campbell Scientific TOA5 data file that is simlar to a csv.

--- a/mock_datalogger/telemetry_post_tester.py
+++ b/mock_datalogger/telemetry_post_tester.py
@@ -96,8 +96,8 @@ def create_test_data(interval: int, idx: int, model: str, sn: str) -> dict:
                 "time": measurement_time_2,
                 "no": idx,
                 "vals": [
-                    round(random.uniform(11.50, 12.50), 2),
-                    round(random.uniform(20.00, 25.00), 2),
+                    "NAN",
+                    "INF",
                 ],
             },
         ],


### PR DESCRIPTION
["NAN" and "INF" can sometimes be sent as measurement values in CR1000X/CR6 payloads.](https://help.campbellsci.com/CR6/Content/shared/Maintain/Troubleshooting/NAN_and_INF.htm?TocPath=Tips%20and%20troubleshooting%7C_____2)

These values are not valid JSON, which causes the unmarshal to error by default. To deal with this edge case, the values are ignored as if they were not uploaded (when unmarshaling JSON payload), considering they indicate an error has occurred. It has been confirmed that this is the desired behavior.