### PR TITLE
Fix Alert Check Measurement Regression

### DIFF
--- a/api/handlers/alert_check.go
+++ b/api/handlers/alert_check.go
@@ -89,6 +89,8 @@ func handleChecks[T models.AlertChecker](db *sqlx.DB, checks []T, alertConfigs [
 					errs = append(errs, err)
 				}
 				ac.AlertStatusID = RedAlertStatusID
+				t := time.Now()
+				ac.LastReminded = &t
 				acIDs = append(acIDs, ac.ID)
 			}
 		case YellowAlertStatusID:
@@ -97,6 +99,8 @@ func handleChecks[T models.AlertChecker](db *sqlx.DB, checks []T, alertConfigs [
 					errs = append(errs, err)
 				}
 				ac.AlertStatusID = RedAlertStatusID
+				t := time.Now()
+				ac.LastReminded = &t
 				acIDs = append(acIDs, ac.ID)
 			} else if !shouldWarn {
 				ac.AlertStatusID = GreenAlertStatusID


### PR DESCRIPTION
## Description

Fixes a regression where Alert Check would only check that ONE timeseries measurement did not upload (instead of checking that ALL uploaded) within the prescribed interval.