### PR TITLE
2.1.0 Release

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2078,6 +2078,177 @@ const docTemplate = `{
                 }
             }
         },
+        "/instruments/ipi/{instrument_id}/measurements": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instrument-ipi"
+                ],
+                "summary": "creates instrument notes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "instrument uuid",
+                        "name": "instrument_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "after time",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "before time",
+                        "name": "before",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiMeasurements"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/instruments/ipi/{instrument_id}/segments": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instrument-ipi"
+                ],
+                "summary": "gets all ipi segments for an instrument",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "instrument uuid",
+                        "name": "instrument_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instrument-ipi"
+                ],
+                "summary": "updates multiple segments for an ipi instrument",
+                "parameters": [
+                    {
+                        "description": "ipi instrument segments payload",
+                        "name": "instrument_segments",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/instruments/notes": {
             "get": {
                 "produces": [
@@ -8427,6 +8598,60 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_USACE_instrumentation-api_api_internal_model.IpiMeasurements": {
+            "type": "object",
+            "properties": {
+                "measurements": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegmentMeasurement"
+                    }
+                },
+                "time": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_USACE_instrumentation-api_api_internal_model.IpiSegment": {
+            "type": "object",
+            "properties": {
+                "cum_dev_timeseries_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "instrument_id": {
+                    "type": "string"
+                },
+                "length": {
+                    "type": "number"
+                },
+                "length_timeseries_id": {
+                    "type": "string"
+                },
+                "tilt_timeseries_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_USACE_instrumentation-api_api_internal_model.IpiSegmentMeasurement": {
+            "type": "object",
+            "properties": {
+                "cum_dev": {
+                    "type": "number"
+                },
+                "elevation": {
+                    "type": "number"
+                },
+                "segment_id": {
+                    "type": "integer"
+                },
+                "tilt": {
+                    "type": "number"
+                }
+            }
+        },
         "github_com_USACE_instrumentation-api_api_internal_model.Measurement": {
             "type": "object",
             "properties": {
@@ -8685,6 +8910,9 @@ const docTemplate = `{
                 "length": {
                     "type": "number"
                 },
+                "length_timeseries_id": {
+                    "type": "string"
+                },
                 "temp_timeseries_id": {
                     "type": "string"
                 },
@@ -8702,19 +8930,46 @@ const docTemplate = `{
         "github_com_USACE_instrumentation-api_api_internal_model.SaaSegmentMeasurement": {
             "type": "object",
             "properties": {
+                "elevation": {
+                    "type": "number"
+                },
                 "segment_id": {
                     "type": "integer"
                 },
                 "temp": {
                     "type": "number"
                 },
+                "temp_cum_dev": {
+                    "type": "number"
+                },
+                "temp_increment": {
+                    "type": "number"
+                },
                 "x": {
+                    "type": "number"
+                },
+                "x_cum_dev": {
+                    "type": "number"
+                },
+                "x_increment": {
                     "type": "number"
                 },
                 "y": {
                     "type": "number"
                 },
+                "y_cum_dev": {
+                    "type": "number"
+                },
+                "y_increment": {
+                    "type": "number"
+                },
                 "z": {
+                    "type": "number"
+                },
+                "z_cum_dev": {
+                    "type": "number"
+                },
+                "z_increment": {
                     "type": "number"
                 }
             }

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -7288,9 +7288,6 @@ const docTemplate = `{
                 "security": [
                     {
                         "Bearer": []
-                    },
-                    {
-                        "Bearer": []
                     }
                 ],
                 "produces": [

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -2070,6 +2070,177 @@
                 }
             }
         },
+        "/instruments/ipi/{instrument_id}/measurements": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instrument-ipi"
+                ],
+                "summary": "creates instrument notes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "instrument uuid",
+                        "name": "instrument_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "after time",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "before time",
+                        "name": "before",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiMeasurements"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/instruments/ipi/{instrument_id}/segments": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instrument-ipi"
+                ],
+                "summary": "gets all ipi segments for an instrument",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "instrument uuid",
+                        "name": "instrument_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instrument-ipi"
+                ],
+                "summary": "updates multiple segments for an ipi instrument",
+                "parameters": [
+                    {
+                        "description": "ipi instrument segments payload",
+                        "name": "instrument_segments",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/instruments/notes": {
             "get": {
                 "produces": [
@@ -8419,6 +8590,60 @@
                 }
             }
         },
+        "github_com_USACE_instrumentation-api_api_internal_model.IpiMeasurements": {
+            "type": "object",
+            "properties": {
+                "measurements": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegmentMeasurement"
+                    }
+                },
+                "time": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_USACE_instrumentation-api_api_internal_model.IpiSegment": {
+            "type": "object",
+            "properties": {
+                "cum_dev_timeseries_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "instrument_id": {
+                    "type": "string"
+                },
+                "length": {
+                    "type": "number"
+                },
+                "length_timeseries_id": {
+                    "type": "string"
+                },
+                "tilt_timeseries_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_USACE_instrumentation-api_api_internal_model.IpiSegmentMeasurement": {
+            "type": "object",
+            "properties": {
+                "cum_dev": {
+                    "type": "number"
+                },
+                "elevation": {
+                    "type": "number"
+                },
+                "segment_id": {
+                    "type": "integer"
+                },
+                "tilt": {
+                    "type": "number"
+                }
+            }
+        },
         "github_com_USACE_instrumentation-api_api_internal_model.Measurement": {
             "type": "object",
             "properties": {
@@ -8677,6 +8902,9 @@
                 "length": {
                     "type": "number"
                 },
+                "length_timeseries_id": {
+                    "type": "string"
+                },
                 "temp_timeseries_id": {
                     "type": "string"
                 },
@@ -8694,19 +8922,46 @@
         "github_com_USACE_instrumentation-api_api_internal_model.SaaSegmentMeasurement": {
             "type": "object",
             "properties": {
+                "elevation": {
+                    "type": "number"
+                },
                 "segment_id": {
                     "type": "integer"
                 },
                 "temp": {
                     "type": "number"
                 },
+                "temp_cum_dev": {
+                    "type": "number"
+                },
+                "temp_increment": {
+                    "type": "number"
+                },
                 "x": {
+                    "type": "number"
+                },
+                "x_cum_dev": {
+                    "type": "number"
+                },
+                "x_increment": {
                     "type": "number"
                 },
                 "y": {
                     "type": "number"
                 },
+                "y_cum_dev": {
+                    "type": "number"
+                },
+                "y_increment": {
+                    "type": "number"
+                },
                 "z": {
+                    "type": "number"
+                },
+                "z_cum_dev": {
+                    "type": "number"
+                },
+                "z_increment": {
                     "type": "number"
                 }
             }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -7280,9 +7280,6 @@
                 "security": [
                     {
                         "Bearer": []
-                    },
-                    {
-                        "Bearer": []
                     }
                 ],
                 "produces": [

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -5874,7 +5874,6 @@ paths:
             $ref: '#/definitions/echo.HTTPError'
       security:
       - Bearer: []
-      - Bearer: []
       summary: updates a single timeseries by id
       tags:
       - timeseries

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -613,6 +613,41 @@ definitions:
           $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.InstrumentStatus'
         type: array
     type: object
+  github_com_USACE_instrumentation-api_api_internal_model.IpiMeasurements:
+    properties:
+      measurements:
+        items:
+          $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegmentMeasurement'
+        type: array
+      time:
+        type: string
+    type: object
+  github_com_USACE_instrumentation-api_api_internal_model.IpiSegment:
+    properties:
+      cum_dev_timeseries_id:
+        type: string
+      id:
+        type: integer
+      instrument_id:
+        type: string
+      length:
+        type: number
+      length_timeseries_id:
+        type: string
+      tilt_timeseries_id:
+        type: string
+    type: object
+  github_com_USACE_instrumentation-api_api_internal_model.IpiSegmentMeasurement:
+    properties:
+      cum_dev:
+        type: number
+      elevation:
+        type: number
+      segment_id:
+        type: integer
+      tilt:
+        type: number
+    type: object
   github_com_USACE_instrumentation-api_api_internal_model.Measurement:
     properties:
       annotation:
@@ -782,6 +817,8 @@ definitions:
         type: string
       length:
         type: number
+      length_timeseries_id:
+        type: string
       temp_timeseries_id:
         type: string
       x_timeseries_id:
@@ -793,15 +830,33 @@ definitions:
     type: object
   github_com_USACE_instrumentation-api_api_internal_model.SaaSegmentMeasurement:
     properties:
+      elevation:
+        type: number
       segment_id:
         type: integer
       temp:
         type: number
+      temp_cum_dev:
+        type: number
+      temp_increment:
+        type: number
       x:
+        type: number
+      x_cum_dev:
+        type: number
+      x_increment:
         type: number
       "y":
         type: number
+      y_cum_dev:
+        type: number
+      y_increment:
+        type: number
       z:
+        type: number
+      z_cum_dev:
+        type: number
+      z_increment:
         type: number
     type: object
   github_com_USACE_instrumentation-api_api_internal_model.SearchResult:
@@ -2757,6 +2812,118 @@ paths:
       summary: gets the total number of non deleted instruments in the system
       tags:
       - instrument
+  /instruments/ipi/{instrument_id}/measurements:
+    get:
+      parameters:
+      - description: instrument uuid
+        format: uuid
+        in: path
+        name: instrument_id
+        required: true
+        type: string
+      - description: after time
+        format: date-time
+        in: query
+        name: after
+        type: string
+      - description: before time
+        format: date-time
+        in: path
+        name: before
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiMeasurements'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+      summary: creates instrument notes
+      tags:
+      - instrument-ipi
+  /instruments/ipi/{instrument_id}/segments:
+    get:
+      parameters:
+      - description: instrument uuid
+        format: uuid
+        in: path
+        name: instrument_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+      summary: gets all ipi segments for an instrument
+      tags:
+      - instrument-ipi
+    put:
+      parameters:
+      - description: ipi instrument segments payload
+        in: body
+        name: instrument_segments
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.IpiSegment'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/echo.HTTPError'
+      security:
+      - Bearer: []
+      summary: updates multiple segments for an ipi instrument
+      tags:
+      - instrument-ipi
   /instruments/notes:
     get:
       produces:

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -31,6 +31,7 @@ type ApiHandler struct {
 	InstrumentGroupService         service.InstrumentGroupService
 	InstrumentNoteService          service.InstrumentNoteService
 	InstrumentStatusService        service.InstrumentStatusService
+	IpiInstrumentService           service.IpiInstrumentService
 	MeasurementService             service.MeasurementService
 	InclinometerMeasurementService service.InclinometerMeasurementService
 	OpendcsService                 service.OpendcsService
@@ -76,6 +77,7 @@ func NewApi(cfg *config.ApiConfig) *ApiHandler {
 		InstrumentGroupService:         service.NewInstrumentGroupService(db, q),
 		InstrumentNoteService:          service.NewInstrumentNoteService(db, q),
 		InstrumentStatusService:        service.NewInstrumentStatusService(db, q),
+		IpiInstrumentService:           service.NewIpiInstrumentService(db, q),
 		MeasurementService:             service.NewMeasurementService(db, q),
 		InclinometerMeasurementService: service.NewInclinometerMeasurementService(db, q),
 		OpendcsService:                 service.NewOpendcsService(db, q),

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/USACE/instrumentation-api/api/internal/cloud"
 	"github.com/USACE/instrumentation-api/api/internal/config"
@@ -142,6 +143,7 @@ func NewDcsLoader(cfg *config.DcsLoaderConfig) *DcsLoaderHandler {
 	blobService := cloud.NewS3Blob(&cfg.AWSS3Config, "", "")
 	ps := cloud.NewSQSPubsub(&cfg.AWSSQSConfig).WithBlob(blobService)
 	apiClient := &http.Client{
+		Timeout: time.Second * 60,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return nil
 		},

--- a/api/internal/handler/instrument.go
+++ b/api/internal/handler/instrument.go
@@ -93,6 +93,7 @@ func (h *ApiHandler) GetInstrument(c echo.Context) error {
 //	@Security Bearer
 //	@Security Bearer
 func (h *ApiHandler) CreateInstruments(c echo.Context) error {
+	ctx := c.Request().Context()
 	newInstrumentCollection := func(c echo.Context) (model.InstrumentCollection, error) {
 		ic := model.InstrumentCollection{}
 		if err := c.Bind(&ic); err != nil {
@@ -106,7 +107,7 @@ func (h *ApiHandler) CreateInstruments(c echo.Context) error {
 		}
 
 		// slugs already taken in the database
-		slugsTaken, err := h.InstrumentService.ListInstrumentSlugs(c.Request().Context())
+		slugsTaken, err := h.InstrumentService.ListInstrumentSlugs(ctx)
 		if err != nil {
 			return model.InstrumentCollection{}, err
 		}
@@ -138,14 +139,14 @@ func (h *ApiHandler) CreateInstruments(c echo.Context) error {
 	}
 
 	if c.QueryParam("dry_run") == "true" {
-		v, err := h.InstrumentService.ValidateCreateInstruments(c.Request().Context(), ic.Items)
+		v, err := h.InstrumentService.ValidateCreateInstruments(ctx, ic.Items)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 		return c.JSON(http.StatusOK, v)
 	}
 
-	nn, err := h.InstrumentService.CreateInstruments(c.Request().Context(), ic.Items)
+	nn, err := h.InstrumentService.CreateInstruments(ctx, ic.Items)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}

--- a/api/internal/handler/instrument_ipi.go
+++ b/api/internal/handler/instrument_ipi.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/USACE/instrumentation-api/api/internal/message"
+	"github.com/USACE/instrumentation-api/api/internal/model"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// GetAllIpiSegmentsForInstrument godoc
+//
+//	@Summary gets all ipi segments for an instrument
+//	@Tags instrument-ipi
+//	@Produce json
+//	@Param instrument_id path string true "instrument uuid" Format(uuid)
+//	@Success 200 {array} model.IpiSegment
+//	@Failure 400 {object} echo.HTTPError
+//	@Failure 404 {object} echo.HTTPError
+//	@Failure 500 {object} echo.HTTPError
+//	@Router /instruments/ipi/{instrument_id}/segments [get]
+func (h *ApiHandler) GetAllIpiSegmentsForInstrument(c echo.Context) error {
+	iID, err := uuid.Parse(c.Param("instrument_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, message.MalformedID)
+	}
+	ss, err := h.IpiInstrumentService.GetAllIpiSegmentsForInstrument(c.Request().Context(), iID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, ss)
+}
+
+// GetIpiMeasurementsForInstrument godoc
+//
+//	@Summary creates instrument notes
+//	@Tags instrument-ipi
+//	@Produce json
+//	@Param instrument_id path string true "instrument uuid" Format(uuid)
+//	@Param after query string false "after time" Format(date-time)
+//	@Param before path string false "before time" Format(date-time)
+//	@Success 200 {array} model.IpiMeasurements
+//	@Failure 400 {object} echo.HTTPError
+//	@Failure 404 {object} echo.HTTPError
+//	@Failure 500 {object} echo.HTTPError
+//	@Router /instruments/ipi/{instrument_id}/measurements [get]
+func (h *ApiHandler) GetIpiMeasurementsForInstrument(c echo.Context) error {
+	iID, err := uuid.Parse(c.Param("instrument_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, message.MalformedID)
+	}
+	var tw model.TimeWindow
+	a, b := c.QueryParam("after"), c.QueryParam("before")
+	if err := tw.SetWindow(a, b, time.Now().AddDate(0, 0, -7), time.Now()); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	mm, err := h.IpiInstrumentService.GetIpiMeasurementsForInstrument(c.Request().Context(), iID, tw)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, mm)
+}
+
+// UpdateIpiSegments godoc
+//
+//	@Summary updates multiple segments for an ipi instrument
+//	@Tags instrument-ipi
+//	@Produce json
+//	@Param instrument_segments body []model.IpiSegment true "ipi instrument segments payload"
+//	@Success 200 {array} model.IpiSegment
+//	@Failure 400 {object} echo.HTTPError
+//	@Failure 404 {object} echo.HTTPError
+//	@Failure 500 {object} echo.HTTPError
+//	@Router /instruments/ipi/{instrument_id}/segments [put]
+//	@Security Bearer
+func (h *ApiHandler) UpdateIpiSegments(c echo.Context) error {
+	segs := make([]model.IpiSegment, 0)
+	if err := c.Bind(&segs); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if err := h.IpiInstrumentService.UpdateIpiSegments(c.Request().Context(), segs); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, segs)
+}

--- a/api/internal/handler/instrument_ipi_test.go
+++ b/api/internal/handler/instrument_ipi_test.go
@@ -1,0 +1,128 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const ipiSegmentArraySchema = `{
+    "type": "array",
+    "properties": {
+        "id": { "type": "string" },
+        "instrument_id": { "type": "string" },
+        "length": { "type": ["number", "null"] },
+        "length_timeseries_id": { "type": "string" },
+        "tilt_timeseries_id": { "type": ["string", "null"] },
+        "cum_dev_timeseries_id": { "type": ["string", "null"] }
+    },
+    "additionalProperties": false
+}`
+
+var ipiSegmentArrayLoader = gojsonschema.NewStringLoader(ipiSegmentArraySchema)
+
+const ipiMeasurementsArraySchema = `{
+    "type": "array",
+    "properties": {
+        "segment_id": { "type": "number" },
+        "instrument_id": { "type": "string" },
+        "tilt": { "type": ["number", "null"] },
+        "cum_dev": { "type": ["number", "null"] },
+	"elevation": { "type": ["number", "null"] }
+    },
+    "additionalProperties": false
+}`
+
+var ipiMeasurementsArrayLoader = gojsonschema.NewStringLoader(ipiMeasurementsArraySchema)
+
+const (
+	testIpiInstrumentID = "01ac435f-fe3c-4af1-9979-f5e00467e7f5"
+	testIpiTimeAfter    = "1900-01-01T00:00:00.00Z"
+	testIpiTimeBefore   = "2030-01-01T00:00:00.00Z"
+)
+
+const updateIpiSegmentsBody = `[
+    {
+        "id": 2,
+        "instrument_id": "01ac435f-fe3c-4af1-9979-f5e00467e7f5",
+        "length": 1,
+        "length_timeseries_id": "e891ca7c-59b2-41bc-9d4a-43995e35b855",
+        "tilt_timeseries_id": null,
+        "cum_dev_timeseries_id": null
+    },
+    {
+        "id": 3,
+        "instrument_id": "01ac435f-fe3c-4af1-9979-f5e00467e7f5",
+        "length": 200,
+        "length_timeseries_id": "18f17db2-4bc8-44cb-a9fa-ba84d13b8444",
+        "tilt_timeseries_id": null,
+        "cum_dev_timeseries_id": null
+    }
+]`
+
+const createIpiInstrumentBulkObjectBody = `{
+    "status_id": "94578354-ffdf-4119-9663-6bd4323e58f5",
+    "status": "destroyed",
+    "status_time": "2001-01-01T00:00:00Z",
+    "slug": "test-ipi-1",
+    "name": "Test IPI 1",
+    "type_id": "c81f3a5d-fc5f-47fd-b545-401fe6ee63bb",
+    "type": "IPI",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -80.8,
+            26.7
+        ]
+    },
+    "formula": null,
+    "station": null,
+    "offset": null,
+    "project_id": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
+    "opts": {
+	"num_segments": 10,
+	"bottom_elevation": 1000
+    }
+}`
+
+func TestIpiInstruments(t *testing.T) {
+	segArrSchema, err := gojsonschema.NewSchema(ipiSegmentArrayLoader)
+	assert.Nil(t, err)
+	measurementsArrSchema, err := gojsonschema.NewSchema(ipiMeasurementsArrayLoader)
+	assert.Nil(t, err)
+
+	tests := []HTTPTest{
+		{
+			Name:           "GetAllIpiSegmentsForInstrument",
+			URL:            fmt.Sprintf("/instruments/ipi/%s/segments", testIpiInstrumentID),
+			Method:         http.MethodGet,
+			ExpectedStatus: http.StatusOK,
+			ExpectedSchema: segArrSchema,
+		},
+		{
+			Name:           "GetIpiMeasurementsForInstrument",
+			URL:            fmt.Sprintf("/instruments/ipi/%s/measurements?after=%s&before=%s", testIpiInstrumentID, testIpiTimeAfter, testIpiTimeBefore),
+			Method:         http.MethodGet,
+			ExpectedStatus: http.StatusOK,
+			ExpectedSchema: measurementsArrSchema,
+		},
+		{
+			Name:           "UpdateIpiSegments",
+			URL:            fmt.Sprintf("/instruments/ipi/%s/segments", testIpiInstrumentID),
+			Method:         http.MethodGet,
+			ExpectedStatus: http.StatusOK,
+			ExpectedSchema: segArrSchema,
+		},
+		{
+			Name:           "CreateIpiInstrumentBulk_Object",
+			URL:            fmt.Sprintf("/projects/%s/instruments", testProjectID),
+			Method:         http.MethodPost,
+			Body:           createIpiInstrumentBulkObjectBody,
+			ExpectedStatus: http.StatusCreated,
+		}}
+
+	RunAll(t, tests)
+}

--- a/api/internal/handler/instrument_saa_test.go
+++ b/api/internal/handler/instrument_saa_test.go
@@ -15,6 +15,7 @@ const saaSegmentArraySchema = `{
         "id": { "type": "string" },
         "instrument_id": { "type": "string" },
         "length": { "type": [ "number", "null" ] },
+        "length_timeseries_id": { "type": "string" },
         "x_timeseries_id": { "type": [ "string", "null" ] },
         "y_timeseries_id": { "type": [ "string", "null" ] },
         "z_timeseries_id": { "type": [ "string", "null" ] },
@@ -30,10 +31,19 @@ const saaMeasurementsArraySchema = `{
     "properties": {
         "segment_id": { "type": "number" },
         "instrument_id": { "type": "string" },
-        "x": { "type": [ "number", "null" ] },
-        "y": { "type": [ "number", "null" ] },
-        "z": { "type": [ "number", "null" ] },
-        "temp": { "type": [ "number", "null" ] }
+        "x": { "type": ["number", "null"] },
+        "y": { "type": ["number", "null"] },
+        "z": { "type": ["number", "null"] },
+        "temp": { "type": [ "number", "null" ] },
+        "x_increment": { "type": ["number", "null"] },
+        "y_increment": { "type": ["number", "null"] },
+        "z_increment": { "type": ["number", "null"] },
+        "temp_increment": { "type": ["number", "null"] },
+        "x_cum_dev": { "type": ["number", "null"] },
+        "y_cum_dev": { "type": ["number", "null"] },
+        "z_cum_dev": { "type": ["number", "null"] },
+        "temp_cum_dev": { "type": ["number", "null"] },
+	"elevation": { "type": ["number", "null"] }
     },
     "additionalProperties": false
 }`
@@ -50,7 +60,8 @@ const updateSaaSegmentsBody = `[
     {
         "id": 5,
         "instrument_id": "eca4040e-aecb-4cd3-bcde-3e308f0356a6",
-        "length": 1,
+        "length": 300,
+	"length_timeseries_id": "ccb80fd4-8902-450f-bb3b-cc1e6718b03c",
         "x_timeseries_id": "eec831d1-56a5-47ef-85eb-02c7622d6cb8",
         "y_timeseries_id": "8b3762ef-a852-4edc-8e87-746a92eaac9d",
         "z_timeseries_id": "ecfa267b-339b-4bb8-b7ae-eda550257878",
@@ -59,13 +70,39 @@ const updateSaaSegmentsBody = `[
     {
         "id": 6,
         "instrument_id": "eca4040e-aecb-4cd3-bcde-3e308f0356a6",
-        "length": 200,
+        "length": 300,
+	"length_timeseries_id": "7f98f239-ac1e-4651-9d69-c163b2dc06a6",
         "x_timeseries_id": "23bda2f6-c479-48e0-a0c2-db48c3b08c3c",
         "y_timeseries_id": "eb25ab9f-af8b-4383-839a-7d24899e02c4",
         "z_timeseries_id": "8e641473-d7bf-433c-a24b-55fa065ca0c3",
         "temp_timeseries_id": "21cfe121-d29d-40a2-b04f-6be71ba479fe"
     }
 ]`
+
+const createSaaInstrumentBulkObjectBody = `{
+    "status_id": "94578354-ffdf-4119-9663-6bd4323e58f5",
+    "status": "destroyed",
+    "status_time": "2001-01-01T00:00:00Z",
+    "slug": "test-saa-1",
+    "name": "Test SAA 1",
+    "type_id": "07b91c5c-c1c5-428d-8bb9-e4c93ab2b9b9",
+    "type": "SAA",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -80.8,
+            26.7
+        ]
+    },
+    "formula": null,
+    "station": null,
+    "offset": null,
+    "project_id": "5b6f4f37-7755-4cf9-bd02-94f1e9bc5984",
+    "opts": {
+	"num_segments": 10,
+	"bottom_elevation": 1000
+    }
+}`
 
 func TestSaaInstruments(t *testing.T) {
 	segArrSchema, err := gojsonschema.NewSchema(saaSegmentArrayLoader)
@@ -94,6 +131,13 @@ func TestSaaInstruments(t *testing.T) {
 			Method:         http.MethodGet,
 			ExpectedStatus: http.StatusOK,
 			ExpectedSchema: segArrSchema,
+		},
+		{
+			Name:           "CreateSaaInstrumentBulk_Object",
+			URL:            fmt.Sprintf("/projects/%s/instruments", testProjectID),
+			Method:         http.MethodPost,
+			Body:           createSaaInstrumentBulkObjectBody,
+			ExpectedStatus: http.StatusCreated,
 		}}
 
 	RunAll(t, tests)

--- a/api/internal/handler/timeseries.go
+++ b/api/internal/handler/timeseries.go
@@ -146,7 +146,6 @@ func (h *ApiHandler) CreateTimeseries(c echo.Context) error {
 		return err
 	}
 	for idx := range tc.Items {
-		tc.Items[idx].ID = uuid.Must(uuid.NewRandom())
 		s, err := util.NextUniqueSlug(tc.Items[idx].Name, slugsTaken)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())

--- a/api/internal/handler/timeseries.go
+++ b/api/internal/handler/timeseries.go
@@ -156,7 +156,7 @@ func (h *ApiHandler) CreateTimeseries(c echo.Context) error {
 
 	tt, err := h.TimeseriesService.CreateTimeseriesBatch(ctx, tc.Items)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusCreated, tt)
 }
@@ -173,7 +173,6 @@ func (h *ApiHandler) CreateTimeseries(c echo.Context) error {
 //	@Failure 404 {object} echo.HTTPError
 //	@Failure 500 {object} echo.HTTPError
 //	@Router /timeseries/{timeseries_id} [put]
-//	@Security Bearer
 //	@Security Bearer
 func (h *ApiHandler) UpdateTimeseries(c echo.Context) error {
 	id, err := uuid.Parse(c.Param("timeseries_id"))

--- a/api/internal/model/instrument_ipi.go
+++ b/api/internal/model/instrument_ipi.go
@@ -61,7 +61,7 @@ const updateIpiOpts = `
 `
 
 func (q *Queries) UpdateIpiOpts(ctx context.Context, instrumentID uuid.UUID, si IpiOpts) error {
-	_, err := q.db.ExecContext(ctx, updateIpiOpts, si.InstrumentID, si.BottomElevationTimeseriesID, si.InitialTime)
+	_, err := q.db.ExecContext(ctx, updateIpiOpts, instrumentID, si.BottomElevationTimeseriesID, si.InitialTime)
 	return err
 }
 

--- a/api/internal/model/instrument_ipi.go
+++ b/api/internal/model/instrument_ipi.go
@@ -1,0 +1,129 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type IpiOpts struct {
+	InstrumentID                uuid.UUID  `json:"-" db:"instrument_id"`
+	NumSegments                 int        `json:"num_segments" db:"num_segments"`
+	BottomElevationTimeseriesID uuid.UUID  `json:"bottom_elevation_timeseries_id" db:"bottom_elevation_timeseries_id"`
+	BottomElevation             float64    `json:"bottom_elevation" db:"bottom_elevation"`
+	InitialTime                 *time.Time `json:"initial_time" db:"initial_time"`
+}
+
+type IpiSegment struct {
+	ID                 int        `json:"id" db:"id"`
+	InstrumentID       uuid.UUID  `json:"instrument_id" db:"instrument_id"`
+	Length             *float64   `json:"length" db:"length"`
+	LengthTimeseriesID uuid.UUID  `json:"length_timeseries_id" db:"length_timeseries_id"`
+	TiltTimeseriesID   *uuid.UUID `json:"tilt_timeseries_id" db:"tilt_timeseries_id"`
+	CumDevTimeseriesID *uuid.UUID `json:"cum_dev_timeseries_id" db:"cum_dev_timeseries_id"`
+}
+
+type IpiMeasurements struct {
+	InstrumentID uuid.UUID                          `json:"-" db:"instrument_id"`
+	Time         time.Time                          `json:"time" db:"time"`
+	Measurements dbJSONSlice[IpiSegmentMeasurement] `json:"measurements" db:"measurements"`
+}
+
+type IpiSegmentMeasurement struct {
+	SegmentID  int      `json:"segment_id" db:"segment_id"`
+	Tilt       *float64 `json:"tilt" db:"tilt"`
+	CumDev     *float64 `json:"cum_dev" db:"cum_dev"`
+	Elelvation *float64 `json:"elevation" db:"elevation"`
+}
+
+var (
+	IpiParameterID = uuid.MustParse("a9a5ad45-b2e5-4744-816e-d3184f2c08bd")
+)
+
+// TODO: when creating new timeseries, any depth based instruments should not be available for assignment
+
+const createIpiOpts = `
+	INSERT INTO ipi_opts (instrument_id, num_segments, bottom_elevation_timeseries_id, initial_time)
+	VALUES ($1, $2, $3, $4)
+`
+
+func (q *Queries) CreateIpiOpts(ctx context.Context, instrumentID uuid.UUID, si IpiOpts) error {
+	_, err := q.db.ExecContext(ctx, createIpiOpts, instrumentID, si.NumSegments, si.BottomElevationTimeseriesID, si.InitialTime)
+	return err
+}
+
+const updateIpiOpts = `
+	UPDATE ipi_opts SET
+		bottom_elevation_timeseries_id = $2,
+		initial_time = $3
+	WHERE instrument_id = $1
+`
+
+func (q *Queries) UpdateIpiOpts(ctx context.Context, instrumentID uuid.UUID, si IpiOpts) error {
+	_, err := q.db.ExecContext(ctx, updateIpiOpts, si.InstrumentID, si.BottomElevationTimeseriesID, si.InitialTime)
+	return err
+}
+
+const getAllIpiSegmentsForInstrument = `
+	SELECT * FROM v_ipi_segment WHERE instrument_id = $1
+`
+
+func (q *Queries) GetAllIpiSegmentsForInstrument(ctx context.Context, instrumentID uuid.UUID) ([]IpiSegment, error) {
+	ssi := make([]IpiSegment, 0)
+	err := q.db.SelectContext(ctx, &ssi, getAllIpiSegmentsForInstrument, instrumentID)
+	return ssi, err
+}
+
+const createIpiSegment = `
+	INSERT INTO ipi_segment (
+		id,
+		instrument_id,
+		length_timeseries_id,
+		tilt_timeseries_id,
+		cum_dev_timeseries_id
+	) VALUES ($1, $2, $3, $4, $5)
+`
+
+func (q *Queries) CreateIpiSegment(ctx context.Context, seg IpiSegment) error {
+	_, err := q.db.ExecContext(ctx, createIpiSegment,
+		seg.ID,
+		seg.InstrumentID,
+		seg.LengthTimeseriesID,
+		seg.TiltTimeseriesID,
+		seg.CumDevTimeseriesID,
+	)
+	return err
+}
+
+const updateIpiSegment = `
+	UPDATE ipi_segment SET
+		length_timeseries_id = $3,
+		tilt_timeseries_id = $4,
+		cum_dev_timeseries_id = $5
+	WHERE id = $1 AND instrument_id = $2
+`
+
+func (q *Queries) UpdateIpiSegment(ctx context.Context, seg IpiSegment) error {
+	_, err := q.db.ExecContext(ctx, updateIpiSegment,
+		seg.ID,
+		seg.InstrumentID,
+		seg.LengthTimeseriesID,
+		seg.TiltTimeseriesID,
+		seg.CumDevTimeseriesID,
+	)
+	return err
+}
+
+const getIpiMeasurementsForInstrument = `
+	SELECT instrument_id, time, measurements
+	FROM v_ipi_measurement
+	WHERE instrument_id = $1 AND time >= $2 AND time <= $3
+	OR time IN (SELECT initial_time FROM ipi_opts WHERE instrument_id = $1)
+`
+
+func (q *Queries) GetIpiMeasurementsForInstrument(ctx context.Context, instrumentID uuid.UUID, tw TimeWindow) ([]IpiMeasurements, error) {
+	mm := make([]IpiMeasurements, 0)
+	err := q.db.SelectContext(ctx, &mm, getIpiMeasurementsForInstrument, instrumentID, tw.Start, tw.End)
+	return mm, err
+}

--- a/api/internal/model/instrument_ipi.go
+++ b/api/internal/model/instrument_ipi.go
@@ -120,6 +120,7 @@ const getIpiMeasurementsForInstrument = `
 	FROM v_ipi_measurement
 	WHERE instrument_id = $1 AND time >= $2 AND time <= $3
 	OR time IN (SELECT initial_time FROM ipi_opts WHERE instrument_id = $1)
+	ORDER BY time ASC
 `
 
 func (q *Queries) GetIpiMeasurementsForInstrument(ctx context.Context, instrumentID uuid.UUID, tw TimeWindow) ([]IpiMeasurements, error) {

--- a/api/internal/model/instrument_saa.go
+++ b/api/internal/model/instrument_saa.go
@@ -140,6 +140,7 @@ const getSaaMeasurementsForInstrument = `
 	FROM v_saa_measurement
 	WHERE instrument_id = $1 AND time >= $2 AND time <= $3
 	OR time IN (SELECT initial_time FROM saa_opts WHERE instrument_id = $1)
+	ORDER BY time ASC
 `
 
 func (q *Queries) GetSaaMeasurementsForInstrument(ctx context.Context, instrumentID uuid.UUID, tw TimeWindow) ([]SaaMeasurements, error) {

--- a/api/internal/model/instrument_saa.go
+++ b/api/internal/model/instrument_saa.go
@@ -8,20 +8,22 @@ import (
 )
 
 type SaaOpts struct {
-	InstrumentID    uuid.UUID  `json:"-" db:"instrument_id"`
-	NumSegments     int        `json:"num_segments" db:"num_segments"`
-	BottomElevation float32    `json:"bottom_elevation" db:"bottom_elevation"`
-	InitialTime     *time.Time `json:"initial_time" db:"initial_time"`
+	InstrumentID                uuid.UUID  `json:"-" db:"instrument_id"`
+	NumSegments                 int        `json:"num_segments" db:"num_segments"`
+	BottomElevationTimeseriesID uuid.UUID  `json:"bottom_elevation_timeseries_id" db:"bottom_elevation_timeseries_id"`
+	BottomElevation             float64    `json:"bottom_elevation" db:"bottom_elevation"`
+	InitialTime                 *time.Time `json:"initial_time" db:"initial_time"`
 }
 
 type SaaSegment struct {
-	ID               int        `json:"id" db:"id"`
-	InstrumentID     uuid.UUID  `json:"instrument_id" db:"instrument_id"`
-	Length           *float32   `json:"length" db:"length"`
-	XTimeseriesID    *uuid.UUID `json:"x_timeseries_id" db:"x_timeseries_id"`
-	YTimeseriesID    *uuid.UUID `json:"y_timeseries_id" db:"y_timeseries_id"`
-	ZTimeseriesID    *uuid.UUID `json:"z_timeseries_id" db:"z_timeseries_id"`
-	TempTimeseriesID *uuid.UUID `json:"temp_timeseries_id" db:"temp_timeseries_id"`
+	ID                 int        `json:"id" db:"id"`
+	InstrumentID       uuid.UUID  `json:"instrument_id" db:"instrument_id"`
+	Length             *float64   `json:"length" db:"length"`
+	LengthTimeseriesID uuid.UUID  `json:"length_timeseries_id" db:"length_timeseries_id"`
+	XTimeseriesID      *uuid.UUID `json:"x_timeseries_id" db:"x_timeseries_id"`
+	YTimeseriesID      *uuid.UUID `json:"y_timeseries_id" db:"y_timeseries_id"`
+	ZTimeseriesID      *uuid.UUID `json:"z_timeseries_id" db:"z_timeseries_id"`
+	TempTimeseriesID   *uuid.UUID `json:"temp_timeseries_id" db:"temp_timeseries_id"`
 }
 
 type SaaMeasurements struct {
@@ -31,34 +33,47 @@ type SaaMeasurements struct {
 }
 
 type SaaSegmentMeasurement struct {
-	SegmentID int      `json:"segment_id" db:"segment_id"`
-	X         *float64 `json:"x" db:"x"`
-	Y         *float64 `json:"y" db:"y"`
-	Z         *float64 `json:"z" db:"z"`
-	Temp      *float64 `json:"temp" db:"temp"`
+	SegmentID     int      `json:"segment_id" db:"segment_id"`
+	X             *float64 `json:"x" db:"x"`
+	Y             *float64 `json:"y" db:"y"`
+	Z             *float64 `json:"z" db:"z"`
+	Temp          *float64 `json:"temp" db:"temp"`
+	XIncrement    *float64 `json:"x_increment" db:"x_increment"`
+	YIncrement    *float64 `json:"y_increment" db:"y_increment"`
+	ZIncrement    *float64 `json:"z_increment" db:"z_increment"`
+	TempIncrement *float64 `json:"temp_increment" db:"temp_increment"`
+	XCumDev       *float64 `json:"x_cum_dev" db:"x_cum_dev"`
+	YCumDev       *float64 `json:"y_cum_dev" db:"y_cum_dev"`
+	ZCumDev       *float64 `json:"z_cum_dev" db:"z_cum_dev"`
+	TempCumDev    *float64 `json:"temp_cum_dev" db:"temp_cum_dev"`
+	Elevation     *float64 `json:"elevation" db:"elevation"`
 }
+
+var (
+	SaaParameterID = uuid.MustParse("6d12ca4c-b618-41cd-87a2-a248980a0d69")
+)
 
 // TODO: when creating new timeseries, any depth based instruments should not be available for assignment
 
 const createSaaOpts = `
-	INSERT INTO saa_opts (instrument_id, num_segments, bottom_elevation, initial_time)
+	INSERT INTO saa_opts (instrument_id, num_segments, bottom_elevation_timeseries_id, initial_time)
 	VALUES ($1, $2, $3, $4)
 `
 
 func (q *Queries) CreateSaaOpts(ctx context.Context, instrumentID uuid.UUID, si SaaOpts) error {
-	_, err := q.db.ExecContext(ctx, createSaaOpts, instrumentID, si.NumSegments, si.BottomElevation, si.InitialTime)
+	_, err := q.db.ExecContext(ctx, createSaaOpts, instrumentID, si.NumSegments, si.BottomElevationTimeseriesID, si.InitialTime)
 	return err
 }
 
 const updateSaaOpts = `
 	UPDATE saa_opts SET
-		bottom_elevation = $2,
+		bottom_elevation_timeseries_id = $2,
 		initial_time = $3
 	WHERE instrument_id = $1
 `
 
 func (q *Queries) UpdateSaaOpts(ctx context.Context, instrumentID uuid.UUID, si SaaOpts) error {
-	_, err := q.db.ExecContext(ctx, updateSaaOpts, si.InstrumentID, si.BottomElevation, si.InitialTime)
+	_, err := q.db.ExecContext(ctx, updateSaaOpts, si.InstrumentID, si.BottomElevationTimeseriesID, si.InitialTime)
 	return err
 }
 
@@ -74,19 +89,21 @@ func (q *Queries) GetAllSaaSegmentsForInstrument(ctx context.Context, instrument
 
 const createSaaSegment = `
 	INSERT INTO saa_segment (
+		id,
 		instrument_id,
-		length,
+		length_timeseries_id,
 		x_timeseries_id,
 		y_timeseries_id,
 		z_timeseries_id,
 		temp_timeseries_id
-	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	) VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 func (q *Queries) CreateSaaSegment(ctx context.Context, seg SaaSegment) error {
 	_, err := q.db.ExecContext(ctx, createSaaSegment,
+		seg.ID,
 		seg.InstrumentID,
-		seg.Length,
+		seg.LengthTimeseriesID,
 		seg.XTimeseriesID,
 		seg.YTimeseriesID,
 		seg.ZTimeseriesID,
@@ -97,7 +114,7 @@ func (q *Queries) CreateSaaSegment(ctx context.Context, seg SaaSegment) error {
 
 const updateSaaSegment = `
 	UPDATE saa_segment SET
-		length = $3,
+		length_timeseries_id = $3,
 		x_timeseries_id = $4,
 		y_timeseries_id = $5,
 		z_timeseries_id = $6,
@@ -109,7 +126,7 @@ func (q *Queries) UpdateSaaSegment(ctx context.Context, seg SaaSegment) error {
 	_, err := q.db.ExecContext(ctx, updateSaaSegment,
 		seg.ID,
 		seg.InstrumentID,
-		seg.Length,
+		seg.LengthTimeseriesID,
 		seg.XTimeseriesID,
 		seg.YTimeseriesID,
 		seg.ZTimeseriesID,
@@ -122,6 +139,7 @@ const getSaaMeasurementsForInstrument = `
 	SELECT instrument_id, time, measurements
 	FROM v_saa_measurement
 	WHERE instrument_id = $1 AND time >= $2 AND time <= $3
+	OR time IN (SELECT initial_time FROM saa_opts WHERE instrument_id = $1)
 `
 
 func (q *Queries) GetSaaMeasurementsForInstrument(ctx context.Context, instrumentID uuid.UUID, tw TimeWindow) ([]SaaMeasurements, error) {

--- a/api/internal/model/instrument_saa.go
+++ b/api/internal/model/instrument_saa.go
@@ -73,7 +73,7 @@ const updateSaaOpts = `
 `
 
 func (q *Queries) UpdateSaaOpts(ctx context.Context, instrumentID uuid.UUID, si SaaOpts) error {
-	_, err := q.db.ExecContext(ctx, updateSaaOpts, si.InstrumentID, si.BottomElevationTimeseriesID, si.InitialTime)
+	_, err := q.db.ExecContext(ctx, updateSaaOpts, instrumentID, si.BottomElevationTimeseriesID, si.InitialTime)
 	return err
 }
 

--- a/api/internal/model/timeseries.go
+++ b/api/internal/model/timeseries.go
@@ -38,6 +38,11 @@ type TimeseriesCollectionItems struct {
 	Items []Timeseries
 }
 
+var (
+	unknownParameterID = uuid.MustParse("2b7f96e1-820f-4f61-ba8f-861640af6232")
+	unknownUnitID      = uuid.MustParse("4a999277-4cf5-4282-93ce-23b33c65e2c8")
+)
+
 // UnmarshalJSON implements UnmarshalJSON interface
 func (c *TimeseriesCollectionItems) UnmarshalJSON(b []byte) error {
 	switch util.JSONType(b) {
@@ -201,6 +206,12 @@ const createTimeseries = `
 
 // CreateTimeseries creates many timeseries from an array of timeseries
 func (q *Queries) CreateTimeseries(ctx context.Context, ts Timeseries) (Timeseries, error) {
+	if ts.ParameterID == uuid.Nil {
+		ts.ParameterID = unknownParameterID
+	}
+	if ts.UnitID == uuid.Nil {
+		ts.UnitID = unknownUnitID
+	}
 	var tsNew Timeseries
 	err := q.db.GetContext(ctx, &tsNew, createTimeseries, ts.InstrumentID, ts.Slug, ts.Name, ts.ParameterID, ts.UnitID)
 	return tsNew, err

--- a/api/internal/model/timeseries.go
+++ b/api/internal/model/timeseries.go
@@ -38,11 +38,6 @@ type TimeseriesCollectionItems struct {
 	Items []Timeseries
 }
 
-var (
-	unknownParameterID = uuid.MustParse("2b7f96e1-820f-4f61-ba8f-861640af6232")
-	unknownUnitID      = uuid.MustParse("4a999277-4cf5-4282-93ce-23b33c65e2c8")
-)
-
 // UnmarshalJSON implements UnmarshalJSON interface
 func (c *TimeseriesCollectionItems) UnmarshalJSON(b []byte) error {
 	switch util.JSONType(b) {
@@ -61,6 +56,11 @@ func (c *TimeseriesCollectionItems) UnmarshalJSON(b []byte) error {
 	}
 	return nil
 }
+
+var (
+	unknownParameterID = uuid.MustParse("2b7f96e1-820f-4f61-ba8f-861640af6232")
+	unknownUnitID      = uuid.MustParse("4a999277-4cf5-4282-93ce-23b33c65e2c8")
+)
 
 const listTimeseries = `
 	SELECT
@@ -224,9 +224,15 @@ const updateTimeseries = `
 `
 
 // UpdateTimeseries updates a timeseries
-func (q *Queries) UpdateTimeseries(ctx context.Context, t Timeseries) (uuid.UUID, error) {
+func (q *Queries) UpdateTimeseries(ctx context.Context, ts Timeseries) (uuid.UUID, error) {
+	if ts.ParameterID == uuid.Nil {
+		ts.ParameterID = unknownParameterID
+	}
+	if ts.UnitID == uuid.Nil {
+		ts.UnitID = unknownUnitID
+	}
 	var tID uuid.UUID
-	err := q.db.GetContext(ctx, &tID, updateTimeseries, t.ID, t.Name, t.InstrumentID, t.ParameterID, t.UnitID)
+	err := q.db.GetContext(ctx, &tID, updateTimeseries, ts.ID, ts.Name, ts.InstrumentID, ts.ParameterID, ts.UnitID)
 	return tID, err
 }
 

--- a/api/internal/model/timeseries_calculated.go
+++ b/api/internal/model/timeseries_calculated.go
@@ -65,6 +65,12 @@ const createCalculatedTimeseries = `
 `
 
 func (q *Queries) CreateCalculatedTimeseries(ctx context.Context, cc CalculatedTimeseries) (uuid.UUID, error) {
+	if cc.ParameterID == uuid.Nil {
+		cc.ParameterID = unknownParameterID
+	}
+	if cc.UnitID == uuid.Nil {
+		cc.UnitID = unknownUnitID
+	}
 	var tsID uuid.UUID
 	err := q.db.GetContext(ctx, &tsID, createCalculatedTimeseries, &cc.InstrumentID, &cc.ParameterID, &cc.UnitID, &cc.Slug, &cc.FormulaName)
 	return tsID, err

--- a/api/internal/model/unit.go
+++ b/api/internal/model/unit.go
@@ -31,3 +31,7 @@ func (q *Queries) ListUnits(ctx context.Context) ([]Unit, error) {
 	}
 	return uu, nil
 }
+
+var (
+	MeterUnitID = uuid.MustParse("ae06a7db-1e18-4994-be41-9d5a408d6cad")
+)

--- a/api/internal/server/api.go
+++ b/api/internal/server/api.go
@@ -186,6 +186,11 @@ func (r *ApiServer) RegisterRoutes(h *handler.ApiHandler) {
 	r.private.POST("/instruments/:instrument_id/status", h.CreateOrUpdateInstrumentStatus)
 	r.private.DELETE("/instruments/:instrument_id/status/:status_id", h.DeleteInstrumentStatus)
 
+	// IpiInstruemnt
+	r.public.GET("/instruments/ipi/:instrument_id/segments", h.GetAllIpiSegmentsForInstrument)
+	r.public.GET("/instruments/ipi/:instrument_id/measurements", h.GetIpiMeasurementsForInstrument)
+	r.private.PUT("/instruments/ipi/:instrument_id/segments", h.UpdateIpiSegments)
+
 	// Measurement
 	r.private.POST("/projects/:project_id/timeseries_measurements", h.CreateOrUpdateProjectTimeseriesMeasurements)
 	r.app.POST("/timeseries_measurements", h.CreateOrUpdateTimeseriesMeasurements)

--- a/api/internal/service/dcsloader.go
+++ b/api/internal/service/dcsloader.go
@@ -42,7 +42,8 @@ func RedactQueryParam(urlErr *url.Error, queryParam string) error {
 	}
 	q := u.Query()
 	q.Set(queryParam, "REDACTED")
-	urlErr.URL = q.Encode()
+	u.RawQuery = q.Encode()
+	urlErr.URL = u.String()
 	return urlErr
 }
 

--- a/api/internal/service/dcsloader.go
+++ b/api/internal/service/dcsloader.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -28,6 +30,20 @@ type dcsLoaderService struct {
 
 func NewDcsLoaderService(apiClient *http.Client, cfg *config.DcsLoaderConfig) *dcsLoaderService {
 	return &dcsLoaderService{apiClient, cfg}
+}
+
+// RedactQueryParam redacts a given url parameter returns the redacted *url.Error
+//
+// https://github.com/golang/go/issues/47442#issuecomment-888554396
+func RedactQueryParam(urlErr *url.Error, queryParam string) error {
+	u, uErr := url.Parse(urlErr.URL)
+	if uErr != nil {
+		return errors.New("unable to parse URL string from urlErr")
+	}
+	q := u.Query()
+	q.Set(queryParam, "REDACTED")
+	urlErr.URL = q.Encode()
+	return urlErr
 }
 
 func (s dcsLoaderService) ParseCsvMeasurementCollection(r io.Reader) ([]model.MeasurementCollection, int, error) {
@@ -99,8 +115,9 @@ func (s dcsLoaderService) PostMeasurementCollectionToApi(mcs []model.Measurement
 
 	resp, err := s.apiClient.Do(req)
 	if err != nil {
-		log.Printf("\n\t*** Error; %s\n", err.Error())
-		return err
+		redactedErr := RedactQueryParam(err.(*url.Error), "key")
+		log.Printf("\n\t*** Error; unable to make request; %s", redactedErr.Error())
+		return redactedErr
 	}
 	defer resp.Body.Close()
 

--- a/api/internal/service/instrument.go
+++ b/api/internal/service/instrument.go
@@ -122,12 +122,12 @@ func (s instrumentService) UpdateInstrument(ctx context.Context, i model.Instrum
 		return model.Instrument{}, err
 	}
 
-	aa, err := qtx.GetInstrument(ctx, i.ID)
-	if err != nil {
+	if err := handleOpts(ctx, qtx, i, update); err != nil {
 		return model.Instrument{}, err
 	}
 
-	if err := handleOpts(ctx, qtx, i, update); err != nil {
+	aa, err := qtx.GetInstrument(ctx, i.ID)
+	if err != nil {
 		return model.Instrument{}, err
 	}
 

--- a/api/internal/service/instrument.go
+++ b/api/internal/service/instrument.go
@@ -32,6 +32,7 @@ func NewInstrumentService(db *model.Database, q *model.Queries) *instrumentServi
 
 var (
 	saaTypeID = uuid.MustParse("07b91c5c-c1c5-428d-8bb9-e4c93ab2b9b9")
+	ipiTypeID = uuid.MustParse("c81f3a5d-fc5f-47fd-b545-401fe6ee63bb")
 )
 
 type requestType int
@@ -40,33 +41,6 @@ const (
 	create requestType = iota
 	update
 )
-
-func handleOpts(ctx context.Context, q *model.Queries, inst model.Instrument, rt requestType) error {
-	switch inst.TypeID {
-	case saaTypeID:
-		opts, err := model.MapToStruct[model.SaaOpts](inst.Opts)
-		if err != nil {
-			return err
-		}
-		if rt == create {
-			if err := q.CreateSaaOpts(ctx, inst.ID, opts); err != nil {
-				return err
-			}
-			for i := 1; i <= opts.NumSegments; i++ {
-				if err := q.CreateSaaSegment(ctx, model.SaaSegment{ID: i, InstrumentID: inst.ID}); err != nil {
-					return err
-				}
-			}
-		}
-		if rt == update {
-			if err := q.UpdateSaaOpts(ctx, inst.ID, opts); err != nil {
-				return err
-			}
-		}
-	default:
-	}
-	return nil
-}
 
 func createInstrument(ctx context.Context, q *model.Queries, instrument model.Instrument) (model.IDAndSlug, error) {
 	newInstrument, err := q.CreateInstrument(ctx, instrument)
@@ -81,6 +55,7 @@ func createInstrument(ctx context.Context, q *model.Queries, instrument model.In
 			return model.IDAndSlug{}, err
 		}
 	}
+	instrument.ID = newInstrument.ID
 	if err := handleOpts(ctx, q, instrument, create); err != nil {
 		return model.IDAndSlug{}, err
 	}

--- a/api/internal/service/instrument_ipi.go
+++ b/api/internal/service/instrument_ipi.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/USACE/instrumentation-api/api/internal/model"
+	"github.com/google/uuid"
+)
+
+type IpiInstrumentService interface {
+	GetAllIpiSegmentsForInstrument(ctx context.Context, instrumentID uuid.UUID) ([]model.IpiSegment, error)
+	UpdateIpiSegment(ctx context.Context, seg model.IpiSegment) error
+	UpdateIpiSegments(ctx context.Context, segs []model.IpiSegment) error
+	GetIpiMeasurementsForInstrument(ctx context.Context, instrumentID uuid.UUID, tw model.TimeWindow) ([]model.IpiMeasurements, error)
+}
+
+type ipiInstrumentService struct {
+	db *model.Database
+	*model.Queries
+}
+
+func NewIpiInstrumentService(db *model.Database, q *model.Queries) *ipiInstrumentService {
+	return &ipiInstrumentService{db, q}
+}
+
+func (s ipiInstrumentService) UpdateIpiSegments(ctx context.Context, segs []model.IpiSegment) error {
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer model.TxDo(tx.Rollback)
+
+	qtx := s.WithTx(tx)
+
+	for _, seg := range segs {
+		if err := qtx.UpdateIpiSegment(ctx, seg); err != nil {
+			return err
+		}
+		if seg.Length == nil {
+			continue
+		}
+		if err := qtx.CreateTimeseriesMeasurement(ctx, seg.LengthTimeseriesID, time.Now(), *seg.Length); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}

--- a/api/internal/service/instrument_opts.go
+++ b/api/internal/service/instrument_opts.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/USACE/instrumentation-api/api/internal/model"
+)
+
+func handleOpts(ctx context.Context, q *model.Queries, inst model.Instrument, rt requestType) error {
+	switch inst.TypeID {
+	case saaTypeID:
+		opts, err := model.MapToStruct[model.SaaOpts](inst.Opts)
+		if err != nil {
+			return err
+		}
+		if rt == create {
+			for i := 1; i <= opts.NumSegments; i++ {
+				tsConstant := model.Timeseries{
+					InstrumentID: inst.ID,
+					Slug:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
+					Name:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
+					ParameterID:  model.SaaParameterID,
+					UnitID:       model.MeterUnitID,
+				}
+
+				tsNew, err := q.CreateTimeseries(ctx, tsConstant)
+				if err != nil {
+					return err
+				}
+				if err := q.CreateInstrumentConstant(ctx, inst.ID, tsNew.ID); err != nil {
+					return err
+				}
+				if err := q.CreateSaaSegment(ctx, model.SaaSegment{ID: i, InstrumentID: inst.ID, LengthTimeseriesID: tsNew.ID}); err != nil {
+					return err
+				}
+			}
+
+			tsConstant := model.Timeseries{
+				InstrumentID: inst.ID,
+				Slug:         inst.Slug + "-bottom-elevation",
+				Name:         inst.Slug + "-bottom-elevation",
+				ParameterID:  model.SaaParameterID,
+				UnitID:       model.MeterUnitID,
+			}
+
+			tsNew, err := q.CreateTimeseries(ctx, tsConstant)
+			if err != nil {
+				return err
+			}
+			if err := q.CreateInstrumentConstant(ctx, inst.ID, tsNew.ID); err != nil {
+				return err
+			}
+			opts.BottomElevationTimeseriesID = tsNew.ID
+			if err := q.CreateSaaOpts(ctx, inst.ID, opts); err != nil {
+				return err
+			}
+		}
+		if rt == update {
+			if err := q.UpdateSaaOpts(ctx, inst.ID, opts); err != nil {
+				return err
+			}
+		}
+		if err := q.CreateTimeseriesMeasurement(ctx, opts.BottomElevationTimeseriesID, time.Now(), opts.BottomElevation); err != nil {
+			return err
+		}
+	case ipiTypeID:
+		opts, err := model.MapToStruct[model.IpiOpts](inst.Opts)
+		if err != nil {
+			return err
+		}
+		if rt == create {
+			for i := 1; i <= opts.NumSegments; i++ {
+				tsConstant := model.Timeseries{
+					InstrumentID: inst.ID,
+					Slug:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
+					Name:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
+					ParameterID:  model.IpiParameterID,
+					UnitID:       model.MeterUnitID,
+				}
+
+				tsNew, err := q.CreateTimeseries(ctx, tsConstant)
+				if err != nil {
+					return err
+				}
+				if err := q.CreateInstrumentConstant(ctx, inst.ID, tsNew.ID); err != nil {
+					return err
+				}
+				if err := q.CreateIpiSegment(ctx, model.IpiSegment{ID: i, InstrumentID: inst.ID, LengthTimeseriesID: tsNew.ID}); err != nil {
+					return err
+				}
+			}
+
+			tsConstant := model.Timeseries{
+				InstrumentID: inst.ID,
+				Slug:         inst.Slug + "-bottom-elevation",
+				Name:         inst.Slug + "-bottom-elevation",
+				ParameterID:  model.IpiParameterID,
+				UnitID:       model.MeterUnitID,
+			}
+
+			tsNew, err := q.CreateTimeseries(ctx, tsConstant)
+			if err != nil {
+				return err
+			}
+			if err := q.CreateInstrumentConstant(ctx, inst.ID, tsNew.ID); err != nil {
+				return err
+			}
+			opts.BottomElevationTimeseriesID = tsNew.ID
+			if err := q.CreateIpiOpts(ctx, inst.ID, opts); err != nil {
+				return err
+			}
+		}
+		if rt == update {
+			if err := q.UpdateIpiOpts(ctx, inst.ID, opts); err != nil {
+				return err
+			}
+		}
+		if err := q.CreateTimeseriesMeasurement(ctx, opts.BottomElevationTimeseriesID, time.Now(), opts.BottomElevation); err != nil {
+			return err
+		}
+	default:
+	}
+	return nil
+}

--- a/api/internal/service/instrument_saa.go
+++ b/api/internal/service/instrument_saa.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/USACE/instrumentation-api/api/internal/model"
 	"github.com/google/uuid"
@@ -34,6 +35,12 @@ func (s saaInstrumentService) UpdateSaaSegments(ctx context.Context, segs []mode
 
 	for _, seg := range segs {
 		if err := qtx.UpdateSaaSegment(ctx, seg); err != nil {
+			return err
+		}
+		if seg.Length == nil {
+			continue
+		}
+		if err := qtx.CreateTimeseriesMeasurement(ctx, seg.LengthTimeseriesID, time.Now(), *seg.Length); err != nil {
 			return err
 		}
 	}

--- a/api/internal/service/timeseries_calculated.go
+++ b/api/internal/service/timeseries_calculated.go
@@ -27,13 +27,6 @@ func NewCalculatedTimeseriesService(db *model.Database, q *model.Queries) *calcu
 }
 
 func (s calculatedTimeseriesService) CreateCalculatedTimeseries(ctx context.Context, cc model.CalculatedTimeseries) error {
-	if cc.ParameterID == uuid.Nil {
-		cc.ParameterID = uuid.Must(uuid.Parse("2b7f96e1-820f-4f61-ba8f-861640af6232")) // unknown parameter
-	}
-	if cc.UnitID == uuid.Nil {
-		cc.UnitID = uuid.Must(uuid.Parse("4a999277-4cf5-4282-93ce-23b33c65e2c8")) // unknown unit
-	}
-
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: db
       args:
         - POSTGRES_VERSION=${POSTGRES_VERSION:-14}
-    command: -c fsync=off
+    command: "-c fsync=off -c search_path=midas,${POSTGRES_USER:-postgres},public,postgis"
     ports:
       - 5432:5432
     shm_size: 512mb

--- a/go.work.sum
+++ b/go.work.sum
@@ -8,11 +8,11 @@ github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/term v0.9.0/go.mod h1:M6DEAAIenWoTxdKrOltXcmDY3rSplQUkrvaDU5FcQyo=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/migrate/common/R__001_functions.sql
+++ b/migrate/common/R__001_functions.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION locf_s(a float, b float)
+RETURNS float
+LANGUAGE SQL
+AS '
+  SELECT COALESCE(b, a)
+';
+
+DROP AGGREGATE IF EXISTS locf(float);
+CREATE AGGREGATE locf(float) (
+  sfunc = locf_s,
+  stype = float
+);

--- a/migrate/common/R__01_roles.sql
+++ b/migrate/common/R__01_roles.sql
@@ -40,6 +40,9 @@ ALTER ROLE instrumentation_user SET search_path TO midas,topology,public;
 -- Set intervalstyle
 ALTER ROLE instrumentation_user SET intervalstyle TO 'iso_8601';
 
+-- Set statement timeout
+ALTER ROLE instrumentation_user SET statement_timeout TO '55s';
+
 -- Grant Schema Usage to instrumentation_user
 GRANT USAGE ON SCHEMA midas TO instrumentation_user;
 

--- a/migrate/common/R__01_roles.sql
+++ b/migrate/common/R__01_roles.sql
@@ -106,7 +106,9 @@ GRANT SELECT ON
     alert_config_instrument,
     submittal,
     saa_opts,
-    saa_segment
+    saa_segment,
+    ipi_opts,
+    ipi_segment
 TO instrumentation_reader;
 
 -- Role instrumentation_writer
@@ -166,7 +168,9 @@ GRANT INSERT,UPDATE,DELETE ON
     alert_config_instrument,
     submittal,
     saa_opts,
-    saa_segment
+    saa_segment,
+    ipi_opts,
+    ipi_segment
 TO instrumentation_writer;
 
 -- Role postgis_reader

--- a/migrate/common/R__14_views_depth_based_instruments.sql
+++ b/migrate/common/R__14_views_depth_based_instruments.sql
@@ -1,59 +1,152 @@
 DROP VIEW IF EXISTS v_saa_segment;
 CREATE VIEW v_saa_segment AS (
     SELECT
-        id,
-        instrument_id,
-        length,
-        x_timeseries_id,
-        y_timeseries_id,
-        z_timeseries_id,
-        temp_timeseries_id
-    FROM saa_segment
+        seg.id,
+        seg.instrument_id,
+        seg.length_timeseries_id,
+        sub.length,
+        seg.x_timeseries_id,
+        seg.y_timeseries_id,
+        seg.z_timeseries_id,
+        seg.temp_timeseries_id
+    FROM saa_segment seg
+    LEFT JOIN LATERAL (
+        SELECT value AS length FROM timeseries_measurement
+        WHERE timeseries_id = seg.length_timeseries_id
+        ORDER BY time DESC
+        LIMIT 1
+    ) sub ON true
 );
 
 DROP VIEW IF EXISTS v_saa_measurement;
 CREATE VIEW v_saa_measurement AS (
     SELECT
-        seg.instrument_id,
-        q.time,
+        r.instrument_id,
+        r.time,
         JSON_AGG(JSON_BUILD_OBJECT(
-            'segment_id', seg.id,
-            'x', q.x,
-            'y', q.y,
-            'z', q.z,
-            'temp', q.temp
-        ) ORDER BY seg.id)::TEXT AS measurements
+            'segment_id',       r.segment_id,
+            'x',                r.x,
+            'y',                r.y,
+            'z',                r.z,
+            'temp',             r.t,
+            'x_increment',      r.x_increment,
+            'y_increment',      r.y_increment,
+            'z_increment',      r.z_increment,
+            'temp_increment',   r.temp_increment,
+            'x_cum_dev',        r.x_cum_dev,
+            'y_cum_dev',        r.y_cum_dev,
+            'z_cum_dev',        r.z_cum_dev,
+            'temp_cum_dev',     r.temp_cum_dev,
+            'elevation',        r.elevation
+        ) ORDER BY r.segment_id)::TEXT AS measurements
+    FROM (SELECT DISTINCT
+        seg.instrument_id,
+        seg.id AS segment_id,
+        q.time,
+        q.x,
+        q.y,
+        q.z,
+        q.t,
+        q.initial_x - q.x x_increment,
+        q.initial_y - q.y y_increment,
+        q.initial_z - q.z z_increment,
+        q.initial_t - q.t temp_increment,
+        SUM(q.initial_x - q.x) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) x_cum_dev,
+        SUM(q.initial_y - q.y) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) y_cum_dev,
+        SUM(q.initial_z - q.z) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) z_cum_dev,
+        SUM(q.initial_t - q.t) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) temp_cum_dev,
+        SUM(q.bottom + q.seg_length) OVER (ORDER BY seg.id DESC) elevation
     FROM saa_segment seg
+    INNER JOIN saa_opts opts ON opts.instrument_id = seg.instrument_id
     LEFT JOIN LATERAL (
-        SELECT sq.time, sq.x, sq.y, sq.z, sq.temp
-        FROM (
-            SELECT
-                a.time,
-                x.value AS x,
-                y.value AS y,
-                z.value AS z,
-                t.value AS "temp"
-            FROM (SELECT DISTINCT time FROM timeseries_measurement WHERE timeseries_id IN (
-                SELECT id FROM timeseries WHERE instrument_id = seg.instrument_id
-            )) a
-            LEFT JOIN (
-                SELECT * FROM timeseries_measurement WHERE timeseries_id = seg.x_timeseries_id
-            ) x ON x.time = a.time
-            LEFT JOIN (
-                SELECT * FROM timeseries_measurement WHERE timeseries_id = seg.y_timeseries_id
-            ) y ON y.time = a.time
-            LEFT JOIN (
-                SELECT * FROM timeseries_measurement WHERE timeseries_id = seg.z_timeseries_id
-            ) z ON z.time = a.time
-            LEFT JOIN (
-                SELECT * FROM timeseries_measurement WHERE timeseries_id = seg.temp_timeseries_id
-            ) t ON t.time = a.time
-        ) sq
-    ) q ON true
-    GROUP BY seg.instrument_id, q.time
+        SELECT
+            a.time,
+            x.value AS x,
+            y.value AS y,
+            z.value AS z,
+            t.value AS t,
+            ia.time AS initial_time,
+            ix.value AS initial_x,
+            iy.value AS initial_y,
+            iz.value AS initial_z,
+            it.value AS initial_t,
+            locf(b.value) OVER (ORDER BY a.time ASC) AS bottom,
+            locf(l.value) OVER (ORDER BY a.time ASC) AS seg_length
+        FROM (SELECT DISTINCT time FROM timeseries_measurement WHERE timeseries_id IN (SELECT id FROM timeseries WHERE instrument_id = seg.instrument_id)) a
+        LEFT JOIN LATERAL (SELECT time FROM timeseries_measurement WHERE time = opts.initial_time) ia ON true
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.x_timeseries_id) x ON x.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.y_timeseries_id) y ON y.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.z_timeseries_id) z ON z.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.temp_timeseries_id) t ON t.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.x_timeseries_id) ix ON ix.time = ia.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.y_timeseries_id) iy ON iy.time = ia.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.z_timeseries_id) iz ON iz.time = ia.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.temp_timeseries_id) it ON it.time = ia.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = opts.bottom_elevation_timeseries_id) b ON b.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.length_timeseries_id) l ON l.time = a.time
+    ) q ON true) r
+    GROUP BY r.instrument_id, r.time
+);
+
+DROP VIEW IF EXISTS v_ipi_segment;
+CREATE VIEW v_ipi_segment AS (
+    SELECT
+        seg.id,
+        seg.instrument_id,
+        seg.length_timeseries_id,
+        sub.length,
+        seg.tilt_timeseries_id,
+        seg.cum_dev_timeseries_id
+    FROM ipi_segment seg
+    LEFT JOIN LATERAL (
+        SELECT value AS length FROM timeseries_measurement
+        WHERE timeseries_id = seg.length_timeseries_id
+        ORDER BY time DESC
+        LIMIT 1
+    ) sub ON true
+);
+
+DROP VIEW IF EXISTS v_ipi_measurement;
+CREATE VIEW v_ipi_measurement AS (
+    SELECT
+        r.instrument_id,
+        r.time,
+        JSON_AGG(JSON_BUILD_OBJECT(
+            'segment_id',   r.segment_id,
+            'tilt',         r.tilt,
+            'cum_dev',      r.cum_dev,
+            'elevation',    r.elevation
+        ) ORDER BY r.segment_id)::TEXT AS measurements
+    FROM (SELECT DISTINCT
+        seg.instrument_id,
+        seg.id AS segment_id,
+        q.seg_length,
+        q.time,
+        q.tilt,
+        COALESCE(q.cum_dev, SIN(q.tilt * PI() / 180) * q.seg_length) cum_dev,
+        SUM(q.bottom + q.seg_length) OVER (ORDER BY seg.id DESC) elevation
+    FROM ipi_segment seg
+    INNER JOIN ipi_opts opts ON opts.instrument_id = seg.instrument_id
+    LEFT JOIN LATERAL (
+        SELECT
+            a.time,
+            t.value AS tilt,
+            d.value AS cum_dev,
+            locf(b.value) OVER (ORDER BY a.time ASC) AS bottom,
+            locf(l.value) OVER (ORDER BY a.time ASC) AS seg_length
+        FROM (SELECT DISTINCT time FROM timeseries_measurement WHERE timeseries_id IN (SELECT id FROM timeseries WHERE instrument_id = seg.instrument_id)) a
+        LEFT JOIN LATERAL (SELECT time FROM timeseries_measurement WHERE time = opts.initial_time) ia ON true
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.tilt_timeseries_id) t ON t.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.cum_dev_timeseries_id) d ON d.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = opts.bottom_elevation_timeseries_id) b ON b.time = a.time
+        LEFT JOIN (SELECT time, value FROM timeseries_measurement WHERE timeseries_id = seg.length_timeseries_id) l ON l.time = a.time
+    ) q ON true) r
+    GROUP BY r.instrument_id, r.time
 );
 
 GRANT SELECT ON
     v_saa_segment,
-    v_saa_measurement
+    v_saa_measurement,
+    v_ipi_segment,
+    v_ipi_measurement
 TO instrumentation_reader;

--- a/migrate/common/R__14_views_depth_based_instruments.sql
+++ b/migrate/common/R__14_views_depth_based_instruments.sql
@@ -51,11 +51,11 @@ CREATE VIEW v_saa_measurement AS (
         q.initial_y - q.y y_increment,
         q.initial_z - q.z z_increment,
         q.initial_t - q.t temp_increment,
-        SUM(q.initial_x - q.x) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) x_cum_dev,
-        SUM(q.initial_y - q.y) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) y_cum_dev,
-        SUM(q.initial_z - q.z) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) z_cum_dev,
-        SUM(q.initial_t - q.t) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id DESC) temp_cum_dev,
-        SUM(q.bottom + q.seg_length) OVER (ORDER BY seg.id DESC) elevation
+        SUM(q.initial_x - q.x) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id ASC) x_cum_dev,
+        SUM(q.initial_y - q.y) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id ASC) y_cum_dev,
+        SUM(q.initial_z - q.z) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id ASC) z_cum_dev,
+        SUM(q.initial_t - q.t) FILTER (WHERE q.time >= q.initial_time) OVER (ORDER BY seg.id ASC) temp_cum_dev,
+        SUM(q.bottom + q.seg_length) OVER (ORDER BY seg.id ASC) elevation
     FROM saa_segment seg
     INNER JOIN saa_opts opts ON opts.instrument_id = seg.instrument_id
     LEFT JOIN LATERAL (
@@ -124,7 +124,7 @@ CREATE VIEW v_ipi_measurement AS (
         q.time,
         q.tilt,
         COALESCE(q.cum_dev, SIN(q.tilt * PI() / 180) * q.seg_length) cum_dev,
-        SUM(q.bottom + q.seg_length) OVER (ORDER BY seg.id DESC) elevation
+        SUM(q.bottom + q.seg_length) OVER (ORDER BY seg.id ASC) elevation
     FROM ipi_segment seg
     INNER JOIN ipi_opts opts ON opts.instrument_id = seg.instrument_id
     LEFT JOIN LATERAL (

--- a/migrate/common/V1.4.0__depth_based_instruments.sql
+++ b/migrate/common/V1.4.0__depth_based_instruments.sql
@@ -1,14 +1,14 @@
-CREATE TABLE IF NOT EXISTS saa_opts (
+CREATE TABLE saa_opts (
     instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
     num_segments INT NOT NULL,
-    bottom_elevation_timeseries_id UUID REFERENCES timeseries (id),
+    bottom_elevation REAL NOT NULL,
     initial_time TIMESTAMPTZ
 );
 
-CREATE TABLE IF NOT EXISTS saa_segment ( 
+CREATE TABLE saa_segment ( 
     instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
     id INT NOT NULL,
-    length_timeseries_id UUID REFERENCES timeseries (id),
+    length REAL,
     x_timeseries_id UUID REFERENCES timeseries (id),
     y_timeseries_id UUID REFERENCES timeseries (id),
     z_timeseries_id UUID REFERENCES timeseries (id),
@@ -17,25 +17,3 @@ CREATE TABLE IF NOT EXISTS saa_segment (
 );
 
 INSERT INTO instrument_type (id, name) VALUES ('07b91c5c-c1c5-428d-8bb9-e4c93ab2b9b9', 'SAA');
-
-INSERT INTO parameter (id, name) VALUES ('6d12ca4c-b618-41cd-87a2-a248980a0d69', 'saa-constant');
-
-CREATE TABLE IF NOT EXISTS ipi_opts (
-    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
-    num_segments INT NOT NULL,
-    bottom_elevation_timeseries_id UUID REFERENCES timeseries (id),
-    initial_time TIMESTAMPTZ
-);
-
-CREATE TABLE IF NOT EXISTS ipi_segment (
-    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
-    id INT NOT NULL,
-    length_timeseries_id UUID REFERENCES timeseries (id),
-    tilt_timeseries_id UUID REFERENCES timeseries (id),
-    cum_dev_timeseries_id UUID REFERENCES timeseries (id),
-    PRIMARY KEY (instrument_id, id)
-);
-
-INSERT INTO instrument_type (id, name) VALUES ('c81f3a5d-fc5f-47fd-b545-401fe6ee63bb', 'IPI');
-
-INSERT INTO parameter (id, name) VALUES ('a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ipi-constant');

--- a/migrate/common/V1.4.0__depth_based_instruments.sql
+++ b/migrate/common/V1.4.0__depth_based_instruments.sql
@@ -1,14 +1,14 @@
-CREATE TABLE saa_opts (
+CREATE TABLE IF NOT EXISTS saa_opts (
     instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
     num_segments INT NOT NULL,
-    bottom_elevation REAL NOT NULL,
+    bottom_elevation_timeseries_id UUID REFERENCES timeseries (id),
     initial_time TIMESTAMPTZ
 );
 
-CREATE TABLE saa_segment ( 
+CREATE TABLE IF NOT EXISTS saa_segment ( 
     instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
     id INT NOT NULL,
-    length REAL,
+    length_timeseries_id UUID REFERENCES timeseries (id),
     x_timeseries_id UUID REFERENCES timeseries (id),
     y_timeseries_id UUID REFERENCES timeseries (id),
     z_timeseries_id UUID REFERENCES timeseries (id),
@@ -17,3 +17,25 @@ CREATE TABLE saa_segment (
 );
 
 INSERT INTO instrument_type (id, name) VALUES ('07b91c5c-c1c5-428d-8bb9-e4c93ab2b9b9', 'SAA');
+
+INSERT INTO parameter (id, name) VALUES ('6d12ca4c-b618-41cd-87a2-a248980a0d69', 'saa-constant');
+
+CREATE TABLE IF NOT EXISTS ipi_opts (
+    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
+    num_segments INT NOT NULL,
+    bottom_elevation_timeseries_id UUID REFERENCES timeseries (id),
+    initial_time TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS ipi_segment (
+    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
+    id INT NOT NULL,
+    length_timeseries_id UUID REFERENCES timeseries (id),
+    tilt_timeseries_id UUID REFERENCES timeseries (id),
+    cum_dev_timeseries_id UUID REFERENCES timeseries (id),
+    PRIMARY KEY (instrument_id, id)
+);
+
+INSERT INTO instrument_type (id, name) VALUES ('c81f3a5d-fc5f-47fd-b545-401fe6ee63bb', 'IPI');
+
+INSERT INTO parameter (id, name) VALUES ('a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ipi-constant');

--- a/migrate/common/V1.4.1__depth_based_instruments_v2.sql
+++ b/migrate/common/V1.4.1__depth_based_instruments_v2.sql
@@ -1,0 +1,41 @@
+DROP TABLE IF EXISTS saa_opts;
+CREATE TABLE IF NOT EXISTS saa_opts (
+    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
+    num_segments INT NOT NULL,
+    bottom_elevation_timeseries_id UUID REFERENCES timeseries (id),
+    initial_time TIMESTAMPTZ
+);
+
+DROP TABLE IF EXISTS saa_segment;
+CREATE TABLE IF NOT EXISTS saa_segment ( 
+    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
+    id INT NOT NULL,
+    length_timeseries_id UUID REFERENCES timeseries (id),
+    x_timeseries_id UUID REFERENCES timeseries (id),
+    y_timeseries_id UUID REFERENCES timeseries (id),
+    z_timeseries_id UUID REFERENCES timeseries (id),
+    temp_timeseries_id UUID REFERENCES timeseries (id),
+    PRIMARY KEY (instrument_id, id)
+);
+
+INSERT INTO parameter (id, name) VALUES ('6d12ca4c-b618-41cd-87a2-a248980a0d69', 'saa-constant');
+
+CREATE TABLE IF NOT EXISTS ipi_opts (
+    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
+    num_segments INT NOT NULL,
+    bottom_elevation_timeseries_id UUID REFERENCES timeseries (id),
+    initial_time TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS ipi_segment (
+    instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,
+    id INT NOT NULL,
+    length_timeseries_id UUID REFERENCES timeseries (id),
+    tilt_timeseries_id UUID REFERENCES timeseries (id),
+    cum_dev_timeseries_id UUID REFERENCES timeseries (id),
+    PRIMARY KEY (instrument_id, id)
+);
+
+INSERT INTO instrument_type (id, name) VALUES ('c81f3a5d-fc5f-47fd-b545-401fe6ee63bb', 'IPI');
+
+INSERT INTO parameter (id, name) VALUES ('a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ipi-constant');

--- a/migrate/common/V1.4.1__depth_based_instruments_v2.sql
+++ b/migrate/common/V1.4.1__depth_based_instruments_v2.sql
@@ -1,3 +1,7 @@
+DROP VIEW IF EXISTS v_instrument;
+DROP VIEW IF EXISTS v_saa_measurement;
+DROP VIEW IF EXISTS v_saa_segment;
+
 DROP TABLE IF EXISTS saa_opts;
 CREATE TABLE IF NOT EXISTS saa_opts (
     instrument_id UUID NOT NULL REFERENCES instrument (id) ON DELETE CASCADE,

--- a/migrate/local/V999.6.0__seed_saa.sql
+++ b/migrate/local/V999.6.0__seed_saa.sql
@@ -4,53 +4,74 @@ INSERT INTO instrument (id, project_id, slug, name, geometry, type_id) VALUES
 INSERT INTO instrument_status (instrument_id, status_id) VALUES ('eca4040e-aecb-4cd3-bcde-3e308f0356a6', 'e26ba2ef-9b52-4c71-97df-9e4b6cf4174d');
 
 INSERT INTO timeseries (id, instrument_id, parameter_id, unit_id, slug, name) VALUES
-('8b3762ef-a852-4edc-8e87-746a92eaac9d', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-1', 'saa-x-1'),
-('ecfa267b-339b-4bb8-b7ae-eda550257878', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-1', 'saa-y-1'),
-('a31a24c4-aa8e-4e52-9895-43cdb69fe703', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-1', 'saa-z-1'),
-('eec831d1-56a5-47ef-85eb-02c7622d6cb8', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-1', 'saa-t-1'),
-('eb25ab9f-af8b-4383-839a-7d24899e02c4', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-2', 'saa-x-2'),
-('8e641473-d7bf-433c-a24b-55fa065ca0c3', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-2', 'saa-y-2'),
-('21cfe121-d29d-40a2-b04f-6be71ba479fe', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-2', 'saa-z-2'),
-('23bda2f6-c479-48e0-a0c2-db48c3b08c3c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-2', 'saa-t-2'),
-('2598aa5f-cb8f-4ab7-8ebf-6de0c30bce70', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-3', 'saa-x-3'),
-('4759bdac-656e-47c3-b403-d3118cf57342', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-3', 'saa-y-3'),
-('1f47a1b9-a2bb-4282-8618-42ba1341533e', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-3', 'saa-z-3'),
-('d2dbac06-ad03-45d9-a7ad-1e7fb9d09ce2', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-3', 'saa-t-3'),
-('c22ffd8a-eae3-41cb-a75b-faae36236465', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-4', 'saa-x-4'),
-('d11a0e91-0125-46cc-a3fc-b0252361bd9c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-4', 'saa-y-4'),
-('9fbf2061-cf73-45f3-9e6c-b745ae7f72a1', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-4', 'saa-z-4'),
-('0503e693-bc58-49b5-a477-288174dc90ed', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-4', 'saa-t-4'),
-('24ad9638-5c5e-48b6-9ad6-a2eb0b93f87c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-5', 'saa-x-5'),
-('8cfaffb4-80b2-411b-be81-776385fc5862', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-5', 'saa-y-5'),
-('ea0f561f-e3f4-4155-a360-17407a0884d4', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-5', 'saa-z-5'),
-('a10e8627-621c-4aa7-8301-a2142a760e0c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-5', 'saa-t-5'),
-('88e22274-021e-4e91-88bb-046b67171a36', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-6', 'saa-x-6'),
-('f684bec8-9cc3-470f-a355-21d65f2be435', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-6', 'saa-y-6'),
-('1a8c9bfc-0e65-4f76-aba9-fc32d643748f', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-6', 'saa-z-6'),
-('2bf6aecd-3df0-4237-b28b-95731b7e333d', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-6', 'saa-t-6'),
-('00f3e1f2-e7ff-4901-abfb-e9bf695802f6', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-7', 'saa-x-7'),
-('2ef9b1d9-ee8f-4f2d-a482-2e0f0dd76f80', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-7', 'saa-y-7'),
-('00ae950d-5bdd-455e-a72a-56da67dafb85', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-7', 'saa-z-7'),
-('3d07cbc0-4aff-4efa-a162-ec1800801665', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-7', 'saa-t-7'),
-('fb0795ba-9d80-4a41-abd7-5de140392454', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-x-8', 'saa-x-8'),
-('32889a6d-93d0-49f9-b281-44e19e88474c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-y-8', 'saa-y-8'),
-('bcb95c35-08f7-4c5a-83ff-b505b8d76481', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-z-8', 'saa-z-8'),
-('54dcd1e1-e9da-4db5-95e5-3c28fab5c03c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-t-8', 'saa-t-8');
+('4affc367-ea0f-41f5-a4bc-5f387b01d7a4', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-bottom-elevation', 'saa-1-bottom-elevation'),
+('cf2f2304-d44e-4363-bc8d-95533222efd6', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-1-length', 'saa-1-segment-1-length'),
+('ff2086ae-0eae-42a8-b598-2e97be2ab3b0', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-2-length', 'saa-1-segment-2-length'),
+('669b63d7-87b2-4aed-9b15-e19ea39789b9', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-3-length', 'saa-1-segment-3-length'),
+('e404e8f4-41c6-4355-9ddb-9d8c635525fc', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-4-length', 'saa-1-segment-4-length'),
+('ccb80fd4-8902-450f-bb3b-cc1e6718b03c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-5-length', 'saa-1-segment-5-length'),
+('7f98f239-ac1e-4651-9d69-c163b2dc06a6', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-6-length', 'saa-1-segment-6-length'),
+('72bd19f1-23d3-4edb-b16f-9ebb121cf921', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-7-length', 'saa-1-segment-7-length'),
+('df6a9cca-29fc-4ec3-9415-d497fbae1a58', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '6d12ca4c-b618-41cd-87a2-a248980a0d69', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'saa-1-segment-8-length', 'saa-1-segment-8-length'),
+('8b3762ef-a852-4edc-8e87-746a92eaac9d', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-1-x', 'saa-1-segment-1-x'),
+('ecfa267b-339b-4bb8-b7ae-eda550257878', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-1-y', 'saa-1-segment-1-y'),
+('a31a24c4-aa8e-4e52-9895-43cdb69fe703', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-1-z', 'saa-1-segment-1-z'),
+('eec831d1-56a5-47ef-85eb-02c7622d6cb8', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-1-t', 'saa-1-segment-1-t'),
+('eb25ab9f-af8b-4383-839a-7d24899e02c4', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-2-x', 'saa-1-segment-2-x'),
+('8e641473-d7bf-433c-a24b-55fa065ca0c3', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-2-y', 'saa-1-segment-2-y'),
+('21cfe121-d29d-40a2-b04f-6be71ba479fe', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-2-z', 'saa-1-segment-2-z'),
+('23bda2f6-c479-48e0-a0c2-db48c3b08c3c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-2-t', 'saa-1-segment-2-t'),
+('2598aa5f-cb8f-4ab7-8ebf-6de0c30bce70', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-3-x', 'saa-1-segment-3-x'),
+('4759bdac-656e-47c3-b403-d3118cf57342', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-3-y', 'saa-1-segment-3-y'),
+('1f47a1b9-a2bb-4282-8618-42ba1341533e', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-3-z', 'saa-1-segment-3-z'),
+('d2dbac06-ad03-45d9-a7ad-1e7fb9d09ce2', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-3-t', 'saa-1-segment-3-t'),
+('c22ffd8a-eae3-41cb-a75b-faae36236465', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-4-x', 'saa-1-segment-4-x'),
+('d11a0e91-0125-46cc-a3fc-b0252361bd9c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-4-y', 'saa-1-segment-4-y'),
+('9fbf2061-cf73-45f3-9e6c-b745ae7f72a1', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-4-z', 'saa-1-segment-4-z'),
+('0503e693-bc58-49b5-a477-288174dc90ed', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-4-t', 'saa-1-segment-4-t'),
+('24ad9638-5c5e-48b6-9ad6-a2eb0b93f87c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-5-x', 'saa-1-segment-5-x'),
+('8cfaffb4-80b2-411b-be81-776385fc5862', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-5-y', 'saa-1-segment-5-y'),
+('ea0f561f-e3f4-4155-a360-17407a0884d4', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-5-z', 'saa-1-segment-5-z'),
+('a10e8627-621c-4aa7-8301-a2142a760e0c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-5-t', 'saa-1-segment-5-t'),
+('88e22274-021e-4e91-88bb-046b67171a36', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-6-x', 'saa-1-segment-6-x'),
+('f684bec8-9cc3-470f-a355-21d65f2be435', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-6-y', 'saa-1-segment-6-y'),
+('1a8c9bfc-0e65-4f76-aba9-fc32d643748f', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-6-z', 'saa-1-segment-6-z'),
+('2bf6aecd-3df0-4237-b28b-95731b7e333d', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-6-t', 'saa-1-segment-6-t'),
+('00f3e1f2-e7ff-4901-abfb-e9bf695802f6', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-7-x', 'saa-1-segment-7-x'),
+('2ef9b1d9-ee8f-4f2d-a482-2e0f0dd76f80', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-7-y', 'saa-1-segment-7-y'),
+('00ae950d-5bdd-455e-a72a-56da67dafb85', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-7-z', 'saa-1-segment-7-z'),
+('3d07cbc0-4aff-4efa-a162-ec1800801665', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-7-t', 'saa-1-segment-7-t'),
+('fb0795ba-9d80-4a41-abd7-5de140392454', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-8-x', 'saa-1-segment-8-x'),
+('32889a6d-93d0-49f9-b281-44e19e88474c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-8-y', 'saa-1-segment-8-y'),
+('bcb95c35-08f7-4c5a-83ff-b505b8d76481', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-8-z', 'saa-1-segment-8-z'),
+('54dcd1e1-e9da-4db5-95e5-3c28fab5c03c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'saa-1-segment-8-t', 'saa-1-segment-8-t');
 
 
-INSERT INTO saa_opts (instrument_id, num_segments, bottom_elevation, initial_time) VALUES
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6', 8, 0, NULL);
+INSERT INTO saa_opts (instrument_id, num_segments, bottom_elevation_timeseries_id, initial_time) VALUES
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6', 8, '4affc367-ea0f-41f5-a4bc-5f387b01d7a4', NOW() - INTERVAL '1 month');
 
 
-INSERT INTO saa_segment (instrument_id, id, length, x_timeseries_id, y_timeseries_id, z_timeseries_id, temp_timeseries_id) VALUES
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',1,200,'8b3762ef-a852-4edc-8e87-746a92eaac9d','ecfa267b-339b-4bb8-b7ae-eda550257878','a31a24c4-aa8e-4e52-9895-43cdb69fe703','eec831d1-56a5-47ef-85eb-02c7622d6cb8'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',2,200,'eb25ab9f-af8b-4383-839a-7d24899e02c4','8e641473-d7bf-433c-a24b-55fa065ca0c3','21cfe121-d29d-40a2-b04f-6be71ba479fe','23bda2f6-c479-48e0-a0c2-db48c3b08c3c'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',3,200,'2598aa5f-cb8f-4ab7-8ebf-6de0c30bce70','4759bdac-656e-47c3-b403-d3118cf57342','1f47a1b9-a2bb-4282-8618-42ba1341533e','d2dbac06-ad03-45d9-a7ad-1e7fb9d09ce2'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',4,200,'c22ffd8a-eae3-41cb-a75b-faae36236465','d11a0e91-0125-46cc-a3fc-b0252361bd9c','9fbf2061-cf73-45f3-9e6c-b745ae7f72a1','0503e693-bc58-49b5-a477-288174dc90ed'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',5,200,'24ad9638-5c5e-48b6-9ad6-a2eb0b93f87c','8cfaffb4-80b2-411b-be81-776385fc5862','ea0f561f-e3f4-4155-a360-17407a0884d4','a10e8627-621c-4aa7-8301-a2142a760e0c'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',6,200,'88e22274-021e-4e91-88bb-046b67171a36','f684bec8-9cc3-470f-a355-21d65f2be435','1a8c9bfc-0e65-4f76-aba9-fc32d643748f','2bf6aecd-3df0-4237-b28b-95731b7e333d'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',7,200,'00f3e1f2-e7ff-4901-abfb-e9bf695802f6','ecfa267b-339b-4bb8-b7ae-eda550257878','00ae950d-5bdd-455e-a72a-56da67dafb85','3d07cbc0-4aff-4efa-a162-ec1800801665'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',8,200,'fb0795ba-9d80-4a41-abd7-5de140392454','32889a6d-93d0-49f9-b281-44e19e88474c','bcb95c35-08f7-4c5a-83ff-b505b8d76481','54dcd1e1-e9da-4db5-95e5-3c28fab5c03c');
+INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES
+('4affc367-ea0f-41f5-a4bc-5f387b01d7a4', NOW() - INTERVAL '1 month', 0),
+('cf2f2304-d44e-4363-bc8d-95533222efd6', NOW() - INTERVAL '1 month', 200),
+('ff2086ae-0eae-42a8-b598-2e97be2ab3b0', NOW() - INTERVAL '1 month', 200),
+('669b63d7-87b2-4aed-9b15-e19ea39789b9', NOW() - INTERVAL '1 month', 200),
+('e404e8f4-41c6-4355-9ddb-9d8c635525fc', NOW() - INTERVAL '1 month', 200),
+('ccb80fd4-8902-450f-bb3b-cc1e6718b03c', NOW() - INTERVAL '1 month', 200),
+('7f98f239-ac1e-4651-9d69-c163b2dc06a6', NOW() - INTERVAL '1 month', 200),
+('72bd19f1-23d3-4edb-b16f-9ebb121cf921', NOW() - INTERVAL '1 month', 200),
+('df6a9cca-29fc-4ec3-9415-d497fbae1a58', NOW() - INTERVAL '1 month', 200);
+
+
+INSERT INTO saa_segment (instrument_id, id, length_timeseries_id, x_timeseries_id, y_timeseries_id, z_timeseries_id, temp_timeseries_id) VALUES
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',1,'cf2f2304-d44e-4363-bc8d-95533222efd6','8b3762ef-a852-4edc-8e87-746a92eaac9d','ecfa267b-339b-4bb8-b7ae-eda550257878','a31a24c4-aa8e-4e52-9895-43cdb69fe703','eec831d1-56a5-47ef-85eb-02c7622d6cb8'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',2,'ff2086ae-0eae-42a8-b598-2e97be2ab3b0','eb25ab9f-af8b-4383-839a-7d24899e02c4','8e641473-d7bf-433c-a24b-55fa065ca0c3','21cfe121-d29d-40a2-b04f-6be71ba479fe','23bda2f6-c479-48e0-a0c2-db48c3b08c3c'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',3,'669b63d7-87b2-4aed-9b15-e19ea39789b9','2598aa5f-cb8f-4ab7-8ebf-6de0c30bce70','4759bdac-656e-47c3-b403-d3118cf57342','1f47a1b9-a2bb-4282-8618-42ba1341533e','d2dbac06-ad03-45d9-a7ad-1e7fb9d09ce2'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',4,'e404e8f4-41c6-4355-9ddb-9d8c635525fc','c22ffd8a-eae3-41cb-a75b-faae36236465','d11a0e91-0125-46cc-a3fc-b0252361bd9c','9fbf2061-cf73-45f3-9e6c-b745ae7f72a1','0503e693-bc58-49b5-a477-288174dc90ed'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',5,'ccb80fd4-8902-450f-bb3b-cc1e6718b03c','24ad9638-5c5e-48b6-9ad6-a2eb0b93f87c','8cfaffb4-80b2-411b-be81-776385fc5862','ea0f561f-e3f4-4155-a360-17407a0884d4','a10e8627-621c-4aa7-8301-a2142a760e0c'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',6,'7f98f239-ac1e-4651-9d69-c163b2dc06a6','88e22274-021e-4e91-88bb-046b67171a36','f684bec8-9cc3-470f-a355-21d65f2be435','1a8c9bfc-0e65-4f76-aba9-fc32d643748f','2bf6aecd-3df0-4237-b28b-95731b7e333d'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',7,'72bd19f1-23d3-4edb-b16f-9ebb121cf921','00f3e1f2-e7ff-4901-abfb-e9bf695802f6','ecfa267b-339b-4bb8-b7ae-eda550257878','00ae950d-5bdd-455e-a72a-56da67dafb85','3d07cbc0-4aff-4efa-a162-ec1800801665'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',8,'df6a9cca-29fc-4ec3-9415-d497fbae1a58','fb0795ba-9d80-4a41-abd7-5de140392454','32889a6d-93d0-49f9-b281-44e19e88474c','bcb95c35-08f7-4c5a-83ff-b505b8d76481','54dcd1e1-e9da-4db5-95e5-3c28fab5c03c');
 
 
 INSERT INTO timeseries_measurement (timeseries_id, time, value)

--- a/migrate/local/V999.6.0__seed_saa.sql
+++ b/migrate/local/V999.6.0__seed_saa.sql
@@ -63,6 +63,18 @@ INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES
 ('df6a9cca-29fc-4ec3-9415-d497fbae1a58', NOW() - INTERVAL '1 month', 200);
 
 
+INSERT INTO instrument_constants (timeseries_id, instrument_id) VALUES
+('4affc367-ea0f-41f5-a4bc-5f387b01d7a4', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('cf2f2304-d44e-4363-bc8d-95533222efd6', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('ff2086ae-0eae-42a8-b598-2e97be2ab3b0', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('669b63d7-87b2-4aed-9b15-e19ea39789b9', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('e404e8f4-41c6-4355-9ddb-9d8c635525fc', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('ccb80fd4-8902-450f-bb3b-cc1e6718b03c', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('7f98f239-ac1e-4651-9d69-c163b2dc06a6', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('72bd19f1-23d3-4edb-b16f-9ebb121cf921', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('df6a9cca-29fc-4ec3-9415-d497fbae1a58', 'eca4040e-aecb-4cd3-bcde-3e308f0356a6');
+
+
 INSERT INTO saa_segment (instrument_id, id, length_timeseries_id, x_timeseries_id, y_timeseries_id, z_timeseries_id, temp_timeseries_id) VALUES
 ('eca4040e-aecb-4cd3-bcde-3e308f0356a6',1,'cf2f2304-d44e-4363-bc8d-95533222efd6','8b3762ef-a852-4edc-8e87-746a92eaac9d','ecfa267b-339b-4bb8-b7ae-eda550257878','a31a24c4-aa8e-4e52-9895-43cdb69fe703','eec831d1-56a5-47ef-85eb-02c7622d6cb8'),
 ('eca4040e-aecb-4cd3-bcde-3e308f0356a6',2,'ff2086ae-0eae-42a8-b598-2e97be2ab3b0','eb25ab9f-af8b-4383-839a-7d24899e02c4','8e641473-d7bf-433c-a24b-55fa065ca0c3','21cfe121-d29d-40a2-b04f-6be71ba479fe','23bda2f6-c479-48e0-a0c2-db48c3b08c3c'),

--- a/migrate/local/V999.6.1__seed_ipi.sql
+++ b/migrate/local/V999.6.1__seed_ipi.sql
@@ -1,0 +1,87 @@
+INSERT INTO instrument (id, project_id, slug, name, geometry, type_id) VALUES
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '5b6f4f37-7755-4cf9-bd02-94f1e9bc5984', 'ipi-1', 'Demo IPI 1', ST_GeomFromText('POINT(-80.8 26.7)',4326), 'c81f3a5d-fc5f-47fd-b545-401fe6ee63bb'),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5', '5b6f4f37-7755-4cf9-bd02-94f1e9bc5984', 'ipi-2', 'Demo IPI 2', ST_GeomFromText('POINT(-80.8 26.7)',4326), 'c81f3a5d-fc5f-47fd-b545-401fe6ee63bb');
+
+INSERT INTO instrument_status (instrument_id, status_id) VALUES
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'e26ba2ef-9b52-4c71-97df-9e4b6cf4174d'),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'e26ba2ef-9b52-4c71-97df-9e4b6cf4174d');
+
+INSERT INTO timeseries (id, instrument_id, parameter_id, unit_id, slug, name) VALUES
+('5842c707-b4be-4d10-a89c-1064e282e555', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-bottom-elevation', 'ipi-1-bottom-elevation'),
+('f7fa0d85-c684-4315-a7c6-e18e60667969', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-1-tilt', 'ipi-1-segment-1-tilt'),
+('1bf787e9-8363-4047-8b03-fbaf9ff03eaf', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-1-cum-dev', 'ipi-1-segment-1-cum-dev'),
+('258a5834-20bf-45fc-a60c-f245b2822592', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-2-tilt', 'ipi-1-segment-2-tilt'),
+('4ffcb98f-962a-46ea-8923-8f992ef07c58', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-2-cum-dev', 'ipi-1-segment-2-cum-dev'),
+('3bd67db5-abd6-4b35-a649-427791f9eeb7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-3-tilt', 'ipi-1-segment-3-tilt'),
+('1db6717b-6cde-4f46-b7fb-bc82b75051d7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-3-cum-dev', 'ipi-1-segment-3-cum-dev'),
+('a3c4254b-1448-4f70-a1b6-d7f5e5c66eb7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-4-tilt', 'ipi-1-segment-4-tilt'),
+('6d90eb76-f292-461e-a82b-0faee9999778', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-4-cum-dev', 'ipi-1-cum-dev-4'),
+('bce99683-59bd-4e4b-ad79-64a03553cfdc', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-1-length', 'ipi-1-segment-1-length'),
+('e891ca7c-59b2-41bc-9d4a-43995e35b855', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-2-length', 'ipi-1-segment-2-length'),
+('18f17db2-4bc8-44cb-a9fa-ba84d13b8444', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-3-length', 'ipi-1-segment-3-length'),
+('d5c236cf-dca5-4a35-bc59-a9ecac4d572b', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-4-length', 'ipi-1-segment-4-length'),
+('7d515571-d6a2-4990-a1e2-d6d42049d864', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-bottom-elevation', 'ipi-2-bottom-elevation'),
+('b2968456-b26a-4bbb-b8d9-f1217a6147ff', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-1-tilt', 'ipi-2-segment-1-tilt'),
+('afcc8471-c91b-466e-833d-f173cc58797f', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-2-tilt', 'ipi-2-segment-2-tilt'),
+('26cb2cfa-910a-46c3-b03f-9dbcf823f8d8', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-3-tilt', 'ipi-2-segment-3-tilt'),
+('3a297a4e-093a-4f9b-b201-1a994e2f4da7', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-4-tilt', 'ipi-2-segment-4-tilt'),
+('88accf78-6f41-4342-86b5-026a8880cbb4', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-1-length', 'ipi-2-segment-1-length'),
+('fc332ef5-55a8-4657-9d6d-b0abeeb985f2', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-2-length', 'ipi-2-segment-2-length'),
+('a86c7468-09a7-4090-98e0-f7979103bbcd', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-3-length', 'ipi-2-segment-3-length'),
+('d28efb95-962d-4233-9002-827154bd76ad', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-4-length', 'ipi-2-segment-4-length');
+
+
+INSERT INTO ipi_opts (instrument_id, num_segments, bottom_elevation_timeseries_id, initial_time) VALUES
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 4, '5842c707-b4be-4d10-a89c-1064e282e555', NOW() - INTERVAL '1 month'),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5', 4, '7d515571-d6a2-4990-a1e2-d6d42049d864', NOW() - INTERVAL '1 month');
+
+
+INSERT INTO ipi_segment (instrument_id, id, length_timeseries_id, tilt_timeseries_id, cum_dev_timeseries_id) VALUES
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',1,'bce99683-59bd-4e4b-ad79-64a03553cfdc','f7fa0d85-c684-4315-a7c6-e18e60667969','1bf787e9-8363-4047-8b03-fbaf9ff03eaf'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',2,'e891ca7c-59b2-41bc-9d4a-43995e35b855','258a5834-20bf-45fc-a60c-f245b2822592','4ffcb98f-962a-46ea-8923-8f992ef07c58'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',3,'18f17db2-4bc8-44cb-a9fa-ba84d13b8444','3bd67db5-abd6-4b35-a649-427791f9eeb7','1db6717b-6cde-4f46-b7fb-bc82b75051d7'),
+('eca4040e-aecb-4cd3-bcde-3e308f0356a6',4,'d5c236cf-dca5-4a35-bc59-a9ecac4d572b','a3c4254b-1448-4f70-a1b6-d7f5e5c66eb7','6d90eb76-f292-461e-a82b-0faee9999778'),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',1,'88accf78-6f41-4342-86b5-026a8880cbb4','b2968456-b26a-4bbb-b8d9-f1217a6147ff', NULL),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',2,'fc332ef5-55a8-4657-9d6d-b0abeeb985f2','afcc8471-c91b-466e-833d-f173cc58797f', NULL),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',3,'a86c7468-09a7-4090-98e0-f7979103bbcd','26cb2cfa-910a-46c3-b03f-9dbcf823f8d8', NULL),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',4,'d28efb95-962d-4233-9002-827154bd76ad','3a297a4e-093a-4f9b-b201-1a994e2f4da7', NULL);
+
+
+INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES
+('5842c707-b4be-4d10-a89c-1064e282e555', NOW() - INTERVAL '1 month', 0),
+('7d515571-d6a2-4990-a1e2-d6d42049d864', NOW() - INTERVAL '1 month', 50),
+('bce99683-59bd-4e4b-ad79-64a03553cfdc', NOW() - INTERVAL '1 month', 012),
+('e891ca7c-59b2-41bc-9d4a-43995e35b855', NOW() - INTERVAL '1 month', 123),
+('18f17db2-4bc8-44cb-a9fa-ba84d13b8444', NOW() - INTERVAL '1 month', 234),
+('d5c236cf-dca5-4a35-bc59-a9ecac4d572b', NOW() - INTERVAL '1 month', 345),
+('88accf78-6f41-4342-86b5-026a8880cbb4', NOW() - INTERVAL '1 month', 100),
+('fc332ef5-55a8-4657-9d6d-b0abeeb985f2', NOW() - INTERVAL '1 month', 200),
+('a86c7468-09a7-4090-98e0-f7979103bbcd', NOW() - INTERVAL '1 month', 150),
+('d28efb95-962d-4233-9002-827154bd76ad', NOW() - INTERVAL '1 month', 050);
+
+
+INSERT INTO timeseries_measurement (timeseries_id, time, value)
+SELECT
+    timeseries_id,
+    time,
+    round((random() * (100-3) + 3)::NUMERIC, 4) AS value
+FROM
+    unnest(ARRAY[
+        'f7fa0d85-c684-4315-a7c6-e18e60667969'::UUID,
+        '1bf787e9-8363-4047-8b03-fbaf9ff03eaf'::UUID,
+        '258a5834-20bf-45fc-a60c-f245b2822592'::UUID,
+        '4ffcb98f-962a-46ea-8923-8f992ef07c58'::UUID,
+        '3bd67db5-abd6-4b35-a649-427791f9eeb7'::UUID,
+        '1db6717b-6cde-4f46-b7fb-bc82b75051d7'::UUID,
+        'a3c4254b-1448-4f70-a1b6-d7f5e5c66eb7'::UUID,
+        '6d90eb76-f292-461e-a82b-0faee9999778'::UUID,
+        'b2968456-b26a-4bbb-b8d9-f1217a6147ff'::UUID,
+        'afcc8471-c91b-466e-833d-f173cc58797f'::UUID,
+        '26cb2cfa-910a-46c3-b03f-9dbcf823f8d8'::UUID,
+        '3a297a4e-093a-4f9b-b201-1a994e2f4da7'::UUID
+]) AS timeseries_id,
+    generate_series(
+        now() - INTERVAL '1 month',
+        now(),
+        INTERVAL '1 hour'
+    ) AS time;

--- a/migrate/local/V999.6.1__seed_ipi.sql
+++ b/migrate/local/V999.6.1__seed_ipi.sql
@@ -60,6 +60,19 @@ INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES
 ('d28efb95-962d-4233-9002-827154bd76ad', NOW() - INTERVAL '1 month', 050);
 
 
+INSERT INTO instrument_constants (timeseries_id, instrument_id) VALUES
+('5842c707-b4be-4d10-a89c-1064e282e555','e29a8c6d-c5a4-4fcc-b269-3a60bd48f929'),
+('7d515571-d6a2-4990-a1e2-d6d42049d864','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
+('bce99683-59bd-4e4b-ad79-64a03553cfdc','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('e891ca7c-59b2-41bc-9d4a-43995e35b855','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('18f17db2-4bc8-44cb-a9fa-ba84d13b8444','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('d5c236cf-dca5-4a35-bc59-a9ecac4d572b','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('88accf78-6f41-4342-86b5-026a8880cbb4','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
+('fc332ef5-55a8-4657-9d6d-b0abeeb985f2','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
+('a86c7468-09a7-4090-98e0-f7979103bbcd','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
+('d28efb95-962d-4233-9002-827154bd76ad','01ac435f-fe3c-4af1-9979-f5e00467e7f5');
+
+
 INSERT INTO timeseries_measurement (timeseries_id, time, value)
 SELECT
     timeseries_id,


### PR DESCRIPTION
## Description
- Adds IPI and SAA measurement aggregation and calculation functionality to the API
  - use instrument constant for segment length and bottom elevation
- Handle case where `parameter_id` or `unit_id` not set in `timeseries`; default to respective "unknown" ids
- Fix dcs-loader logs