### PR TITLE
update ipi fields

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -8612,11 +8612,11 @@ const docTemplate = `{
         "github_com_USACE_instrumentation-api_api_internal_model.IpiSegment": {
             "type": "object",
             "properties": {
-                "cum_dev_timeseries_id": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
+                },
+                "inc_dev_timeseries_id": {
+                    "type": "string"
                 },
                 "instrument_id": {
                     "type": "string"
@@ -8625,6 +8625,9 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "length_timeseries_id": {
+                    "type": "string"
+                },
+                "temp_timeseries_id": {
                     "type": "string"
                 },
                 "tilt_timeseries_id": {
@@ -8641,8 +8644,14 @@ const docTemplate = `{
                 "elevation": {
                     "type": "number"
                 },
+                "inc_dev": {
+                    "type": "number"
+                },
                 "segment_id": {
                     "type": "integer"
+                },
+                "temp": {
+                    "type": "number"
                 },
                 "tilt": {
                     "type": "number"

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -8604,11 +8604,11 @@
         "github_com_USACE_instrumentation-api_api_internal_model.IpiSegment": {
             "type": "object",
             "properties": {
-                "cum_dev_timeseries_id": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
+                },
+                "inc_dev_timeseries_id": {
+                    "type": "string"
                 },
                 "instrument_id": {
                     "type": "string"
@@ -8617,6 +8617,9 @@
                     "type": "number"
                 },
                 "length_timeseries_id": {
+                    "type": "string"
+                },
+                "temp_timeseries_id": {
                     "type": "string"
                 },
                 "tilt_timeseries_id": {
@@ -8633,8 +8636,14 @@
                 "elevation": {
                     "type": "number"
                 },
+                "inc_dev": {
+                    "type": "number"
+                },
                 "segment_id": {
                     "type": "integer"
+                },
+                "temp": {
+                    "type": "number"
                 },
                 "tilt": {
                     "type": "number"

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -624,15 +624,17 @@ definitions:
     type: object
   github_com_USACE_instrumentation-api_api_internal_model.IpiSegment:
     properties:
-      cum_dev_timeseries_id:
-        type: string
       id:
         type: integer
+      inc_dev_timeseries_id:
+        type: string
       instrument_id:
         type: string
       length:
         type: number
       length_timeseries_id:
+        type: string
+      temp_timeseries_id:
         type: string
       tilt_timeseries_id:
         type: string
@@ -643,8 +645,12 @@ definitions:
         type: number
       elevation:
         type: number
+      inc_dev:
+        type: number
       segment_id:
         type: integer
+      temp:
+        type: number
       tilt:
         type: number
     type: object

--- a/api/internal/handler/instrument_ipi_test.go
+++ b/api/internal/handler/instrument_ipi_test.go
@@ -17,7 +17,8 @@ const ipiSegmentArraySchema = `{
         "length": { "type": ["number", "null"] },
         "length_timeseries_id": { "type": "string" },
         "tilt_timeseries_id": { "type": ["string", "null"] },
-        "cum_dev_timeseries_id": { "type": ["string", "null"] }
+        "inc_dev_timeseries_id": { "type": ["string", "null"] },
+        "temp_timeseries_id": { "type": ["string", "null"] }
     },
     "additionalProperties": false
 }`
@@ -31,6 +32,8 @@ const ipiMeasurementsArraySchema = `{
         "instrument_id": { "type": "string" },
         "tilt": { "type": ["number", "null"] },
         "cum_dev": { "type": ["number", "null"] },
+        "inc_dev": { "type": ["number", "null"] },
+        "temp": { "type": ["number", "null"] },
 	"elevation": { "type": ["number", "null"] }
     },
     "additionalProperties": false
@@ -51,7 +54,8 @@ const updateIpiSegmentsBody = `[
         "length": 1,
         "length_timeseries_id": "e891ca7c-59b2-41bc-9d4a-43995e35b855",
         "tilt_timeseries_id": null,
-        "cum_dev_timeseries_id": null
+        "inc_dev_timeseries_id": null,
+        "temp_timeseries_id": null
     },
     {
         "id": 3,
@@ -59,7 +63,8 @@ const updateIpiSegmentsBody = `[
         "length": 200,
         "length_timeseries_id": "18f17db2-4bc8-44cb-a9fa-ba84d13b8444",
         "tilt_timeseries_id": null,
-        "cum_dev_timeseries_id": null
+        "inc_dev_timeseries_id": null,
+        "temp_timeseries_id": null
     }
 ]`
 

--- a/api/internal/model/instrument_ipi.go
+++ b/api/internal/model/instrument_ipi.go
@@ -21,7 +21,8 @@ type IpiSegment struct {
 	Length             *float64   `json:"length" db:"length"`
 	LengthTimeseriesID uuid.UUID  `json:"length_timeseries_id" db:"length_timeseries_id"`
 	TiltTimeseriesID   *uuid.UUID `json:"tilt_timeseries_id" db:"tilt_timeseries_id"`
-	CumDevTimeseriesID *uuid.UUID `json:"cum_dev_timeseries_id" db:"cum_dev_timeseries_id"`
+	IncDevTimeseriesID *uuid.UUID `json:"inc_dev_timeseries_id" db:"inc_dev_timeseries_id"`
+	TempTimeseriesID   *uuid.UUID `json:"temp_timeseries_id" db:"temp_timeseries_id"`
 }
 
 type IpiMeasurements struct {
@@ -33,7 +34,9 @@ type IpiMeasurements struct {
 type IpiSegmentMeasurement struct {
 	SegmentID  int      `json:"segment_id" db:"segment_id"`
 	Tilt       *float64 `json:"tilt" db:"tilt"`
+	IncDev     *float64 `json:"inc_dev" db:"inc_dev"`
 	CumDev     *float64 `json:"cum_dev" db:"cum_dev"`
+	Temp       *float64 `json:"temp" db:"temp"`
 	Elelvation *float64 `json:"elevation" db:"elevation"`
 }
 
@@ -81,8 +84,9 @@ const createIpiSegment = `
 		instrument_id,
 		length_timeseries_id,
 		tilt_timeseries_id,
-		cum_dev_timeseries_id
-	) VALUES ($1, $2, $3, $4, $5)
+		inc_dev_timeseries_id,
+		temp_timeseries_id
+	) VALUES ($1, $2, $3, $4, $5, $6)
 `
 
 func (q *Queries) CreateIpiSegment(ctx context.Context, seg IpiSegment) error {
@@ -91,7 +95,8 @@ func (q *Queries) CreateIpiSegment(ctx context.Context, seg IpiSegment) error {
 		seg.InstrumentID,
 		seg.LengthTimeseriesID,
 		seg.TiltTimeseriesID,
-		seg.CumDevTimeseriesID,
+		seg.IncDevTimeseriesID,
+		seg.TempTimeseriesID,
 	)
 	return err
 }
@@ -100,7 +105,8 @@ const updateIpiSegment = `
 	UPDATE ipi_segment SET
 		length_timeseries_id = $3,
 		tilt_timeseries_id = $4,
-		cum_dev_timeseries_id = $5
+		inc_dev_timeseries_id = $5,
+		temp_timeseries_id = $6
 	WHERE id = $1 AND instrument_id = $2
 `
 
@@ -110,7 +116,8 @@ func (q *Queries) UpdateIpiSegment(ctx context.Context, seg IpiSegment) error {
 		seg.InstrumentID,
 		seg.LengthTimeseriesID,
 		seg.TiltTimeseriesID,
-		seg.CumDevTimeseriesID,
+		seg.IncDevTimeseriesID,
+		seg.TempTimeseriesID,
 	)
 	return err
 }

--- a/api/internal/model/unit.go
+++ b/api/internal/model/unit.go
@@ -17,6 +17,11 @@ type Unit struct {
 	Measure      string    `json:"measure"`
 }
 
+var (
+	MeterUnitID = uuid.MustParse("ae06a7db-1e18-4994-be41-9d5a408d6cad")
+	FeetUnitID  = uuid.MustParse("f777f2e2-5e32-424e-a1ca-19d16cd8abce")
+)
+
 const listUnits = `
 	SELECT id, name, abbreviation, unit_family_id, unit_family, measure_id, measure
 	FROM v_unit
@@ -31,7 +36,3 @@ func (q *Queries) ListUnits(ctx context.Context) ([]Unit, error) {
 	}
 	return uu, nil
 }
-
-var (
-	MeterUnitID = uuid.MustParse("ae06a7db-1e18-4994-be41-9d5a408d6cad")
-)

--- a/api/internal/service/instrument_opts.go
+++ b/api/internal/service/instrument_opts.go
@@ -22,7 +22,7 @@ func handleOpts(ctx context.Context, q *model.Queries, inst model.Instrument, rt
 					Slug:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
 					Name:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
 					ParameterID:  model.SaaParameterID,
-					UnitID:       model.MeterUnitID,
+					UnitID:       model.FeetUnitID,
 				}
 
 				tsNew, err := q.CreateTimeseries(ctx, tsConstant)
@@ -42,7 +42,7 @@ func handleOpts(ctx context.Context, q *model.Queries, inst model.Instrument, rt
 				Slug:         inst.Slug + "-bottom-elevation",
 				Name:         inst.Slug + "-bottom-elevation",
 				ParameterID:  model.SaaParameterID,
-				UnitID:       model.MeterUnitID,
+				UnitID:       model.FeetUnitID,
 			}
 
 			tsNew, err := q.CreateTimeseries(ctx, tsConstant)
@@ -77,7 +77,7 @@ func handleOpts(ctx context.Context, q *model.Queries, inst model.Instrument, rt
 					Slug:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
 					Name:         inst.Slug + fmt.Sprintf("segment-%d-length", i),
 					ParameterID:  model.IpiParameterID,
-					UnitID:       model.MeterUnitID,
+					UnitID:       model.FeetUnitID,
 				}
 
 				tsNew, err := q.CreateTimeseries(ctx, tsConstant)
@@ -97,7 +97,7 @@ func handleOpts(ctx context.Context, q *model.Queries, inst model.Instrument, rt
 				Slug:         inst.Slug + "-bottom-elevation",
 				Name:         inst.Slug + "-bottom-elevation",
 				ParameterID:  model.IpiParameterID,
-				UnitID:       model.MeterUnitID,
+				UnitID:       model.FeetUnitID,
 			}
 
 			tsNew, err := q.CreateTimeseries(ctx, tsConstant)

--- a/migrate/common/R__04_views_instruments.sql
+++ b/migrate/common/R__04_views_instruments.sql
@@ -10,7 +10,6 @@ CREATE OR REPLACE VIEW v_instrument_telemetry AS (
     LEFT JOIN telemetry_iridium ti ON a.telemetry_id = ti.id
 );
 
--- v_instrument
 CREATE OR REPLACE VIEW v_instrument AS (
     SELECT
         i.id,
@@ -105,23 +104,20 @@ CREATE OR REPLACE VIEW v_instrument AS (
     ) o ON o.instrument_id = i.id
 );
 
--- v_instrument_groups
 CREATE OR REPLACE VIEW v_instrument_group AS (
     WITH instrument_count AS (
-        SELECT 
-        igi.instrument_group_id,
-        count(igi.instrument_group_id) as i_count 
-        FROM instrument_group_instruments igi
-        JOIN instrument i on igi.instrument_id = i.id and not i.deleted
-        GROUP BY igi.instrument_group_id
-        )
-        ,
+            SELECT 
+            igi.instrument_group_id,
+            count(igi.instrument_group_id) as i_count 
+            FROM instrument_group_instruments igi
+            JOIN instrument i on igi.instrument_id = i.id and not i.deleted
+            GROUP BY igi.instrument_group_id
+        ),
         timeseries_instruments as (
             SELECT t.id, t.instrument_id, igi.instrument_group_id from timeseries t 
             JOIN instrument i on i.id = t.instrument_id and not i.deleted
             JOIN instrument_group_instruments igi on igi.instrument_id = i.id
         )
-
         SELECT  ig.id,
                 ig.slug,
                 ig.name,
@@ -134,13 +130,9 @@ CREATE OR REPLACE VIEW v_instrument_group AS (
                 ig.deleted,
                 COALESCE(ic.i_count,0) as instrument_count,
                 COALESCE(count(ti.id),0) as timeseries_count
-                --,
-                --COALESCE(count(tm.timeseries_id),0) as timeseries_measurements_count
-                
         FROM instrument_group ig
         LEFT JOIN instrument_count ic on ic.instrument_group_id = ig.id
         LEFT JOIN timeseries_instruments ti on ig.id = ti.instrument_group_id
-        --left join timeseries_measurement tm on tm.timeseries_id = ti.id
         GROUP BY ig.id, ic.i_count
         ORDER BY ig.name
 );

--- a/migrate/common/V1.4.2__depth_based_instruments_v3.sql
+++ b/migrate/common/V1.4.2__depth_based_instruments_v3.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ipi_segment ADD COLUMN temp_timeseries_id UUID REFERENCES timeseries (id);
+ALTER TABLE ipi_segment RENAME COLUMN cum_dev_timeseries_id TO inc_dev_timeseries_id;

--- a/migrate/local/V999.6.1__seed_ipi.sql
+++ b/migrate/local/V999.6.1__seed_ipi.sql
@@ -7,44 +7,47 @@ INSERT INTO instrument_status (instrument_id, status_id) VALUES
 ('01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'e26ba2ef-9b52-4c71-97df-9e4b6cf4174d');
 
 INSERT INTO timeseries (id, instrument_id, parameter_id, unit_id, slug, name) VALUES
-('5842c707-b4be-4d10-a89c-1064e282e555', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-bottom-elevation', 'ipi-1-bottom-elevation'),
+('5842c707-b4be-4d10-a89c-1064e282e555', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-1-bottom-elevation', 'ipi-1-bottom-elevation'),
 ('f7fa0d85-c684-4315-a7c6-e18e60667969', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-1-tilt', 'ipi-1-segment-1-tilt'),
-('1bf787e9-8363-4047-8b03-fbaf9ff03eaf', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-1-cum-dev', 'ipi-1-segment-1-cum-dev'),
+('1bf787e9-8363-4047-8b03-fbaf9ff03eaf', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-1-inc-dev', 'ipi-1-segment-1-inc-dev'),
+('8d10fbd9-2669-4727-b4c1-746361691388', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-1-temp', 'ipi-1-segment-1-temp'),
 ('258a5834-20bf-45fc-a60c-f245b2822592', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-2-tilt', 'ipi-1-segment-2-tilt'),
-('4ffcb98f-962a-46ea-8923-8f992ef07c58', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-2-cum-dev', 'ipi-1-segment-2-cum-dev'),
+('4ffcb98f-962a-46ea-8923-8f992ef07c58', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-2-inc-dev', 'ipi-1-segment-2-inc-dev'),
+('6044cffb-c241-4b66-9873-068c2bbac451', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-2-temp', 'ipi-1-segment-2-temp'),
 ('3bd67db5-abd6-4b35-a649-427791f9eeb7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-3-tilt', 'ipi-1-segment-3-tilt'),
-('1db6717b-6cde-4f46-b7fb-bc82b75051d7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-3-cum-dev', 'ipi-1-segment-3-cum-dev'),
+('1db6717b-6cde-4f46-b7fb-bc82b75051d7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-3-inc-dev', 'ipi-1-segment-3-inc-dev'),
+('98385e5a-c5d8-4441-aa2e-0f6120414352', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-3-temp', 'ipi-1-segment-3-temp'),
 ('a3c4254b-1448-4f70-a1b6-d7f5e5c66eb7', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-4-tilt', 'ipi-1-segment-4-tilt'),
-('6d90eb76-f292-461e-a82b-0faee9999778', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-4-cum-dev', 'ipi-1-cum-dev-4'),
-('bce99683-59bd-4e4b-ad79-64a03553cfdc', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-1-length', 'ipi-1-segment-1-length'),
-('e891ca7c-59b2-41bc-9d4a-43995e35b855', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-2-length', 'ipi-1-segment-2-length'),
-('18f17db2-4bc8-44cb-a9fa-ba84d13b8444', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-3-length', 'ipi-1-segment-3-length'),
-('d5c236cf-dca5-4a35-bc59-a9ecac4d572b', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-1-segment-4-length', 'ipi-1-segment-4-length'),
-('7d515571-d6a2-4990-a1e2-d6d42049d864', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-bottom-elevation', 'ipi-2-bottom-elevation'),
+('6d90eb76-f292-461e-a82b-0faee9999778', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-4-inc-dev', 'ipi-1-segment-4-inc-dev'),
+('c488fc08-18ff-4e3d-851f-46cfd1257b6c', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-1-segment-4-temp', 'ipi-1-segment-4-temp'),
+('bce99683-59bd-4e4b-ad79-64a03553cfdc', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-1-segment-1-length', 'ipi-1-segment-1-length'),
+('e891ca7c-59b2-41bc-9d4a-43995e35b855', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-1-segment-2-length', 'ipi-1-segment-2-length'),
+('18f17db2-4bc8-44cb-a9fa-ba84d13b8444', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-1-segment-3-length', 'ipi-1-segment-3-length'),
+('d5c236cf-dca5-4a35-bc59-a9ecac4d572b', 'e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-1-segment-4-length', 'ipi-1-segment-4-length'),
+('7d515571-d6a2-4990-a1e2-d6d42049d864', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-2-bottom-elevation', 'ipi-2-bottom-elevation'),
 ('b2968456-b26a-4bbb-b8d9-f1217a6147ff', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-1-tilt', 'ipi-2-segment-1-tilt'),
 ('afcc8471-c91b-466e-833d-f173cc58797f', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-2-tilt', 'ipi-2-segment-2-tilt'),
 ('26cb2cfa-910a-46c3-b03f-9dbcf823f8d8', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-3-tilt', 'ipi-2-segment-3-tilt'),
 ('3a297a4e-093a-4f9b-b201-1a994e2f4da7', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'ipi-2-segment-4-tilt', 'ipi-2-segment-4-tilt'),
-('88accf78-6f41-4342-86b5-026a8880cbb4', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-1-length', 'ipi-2-segment-1-length'),
-('fc332ef5-55a8-4657-9d6d-b0abeeb985f2', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-2-length', 'ipi-2-segment-2-length'),
-('a86c7468-09a7-4090-98e0-f7979103bbcd', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-3-length', 'ipi-2-segment-3-length'),
-('d28efb95-962d-4233-9002-827154bd76ad', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'ae06a7db-1e18-4994-be41-9d5a408d6cad', 'ipi-2-segment-4-length', 'ipi-2-segment-4-length');
-
+('88accf78-6f41-4342-86b5-026a8880cbb4', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-2-segment-1-length', 'ipi-2-segment-1-length'),
+('fc332ef5-55a8-4657-9d6d-b0abeeb985f2', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-2-segment-2-length', 'ipi-2-segment-2-length'),
+('a86c7468-09a7-4090-98e0-f7979103bbcd', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-2-segment-3-length', 'ipi-2-segment-3-length'),
+('d28efb95-962d-4233-9002-827154bd76ad', '01ac435f-fe3c-4af1-9979-f5e00467e7f5', 'a9a5ad45-b2e5-4744-816e-d3184f2c08bd', 'f777f2e2-5e32-424e-a1ca-19d16cd8abce', 'ipi-2-segment-4-length', 'ipi-2-segment-4-length');
 
 INSERT INTO ipi_opts (instrument_id, num_segments, bottom_elevation_timeseries_id, initial_time) VALUES
 ('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929', 4, '5842c707-b4be-4d10-a89c-1064e282e555', NOW() - INTERVAL '1 month'),
 ('01ac435f-fe3c-4af1-9979-f5e00467e7f5', 4, '7d515571-d6a2-4990-a1e2-d6d42049d864', NOW() - INTERVAL '1 month');
 
 
-INSERT INTO ipi_segment (instrument_id, id, length_timeseries_id, tilt_timeseries_id, cum_dev_timeseries_id) VALUES
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',1,'bce99683-59bd-4e4b-ad79-64a03553cfdc','f7fa0d85-c684-4315-a7c6-e18e60667969','1bf787e9-8363-4047-8b03-fbaf9ff03eaf'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',2,'e891ca7c-59b2-41bc-9d4a-43995e35b855','258a5834-20bf-45fc-a60c-f245b2822592','4ffcb98f-962a-46ea-8923-8f992ef07c58'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',3,'18f17db2-4bc8-44cb-a9fa-ba84d13b8444','3bd67db5-abd6-4b35-a649-427791f9eeb7','1db6717b-6cde-4f46-b7fb-bc82b75051d7'),
-('eca4040e-aecb-4cd3-bcde-3e308f0356a6',4,'d5c236cf-dca5-4a35-bc59-a9ecac4d572b','a3c4254b-1448-4f70-a1b6-d7f5e5c66eb7','6d90eb76-f292-461e-a82b-0faee9999778'),
-('01ac435f-fe3c-4af1-9979-f5e00467e7f5',1,'88accf78-6f41-4342-86b5-026a8880cbb4','b2968456-b26a-4bbb-b8d9-f1217a6147ff', NULL),
-('01ac435f-fe3c-4af1-9979-f5e00467e7f5',2,'fc332ef5-55a8-4657-9d6d-b0abeeb985f2','afcc8471-c91b-466e-833d-f173cc58797f', NULL),
-('01ac435f-fe3c-4af1-9979-f5e00467e7f5',3,'a86c7468-09a7-4090-98e0-f7979103bbcd','26cb2cfa-910a-46c3-b03f-9dbcf823f8d8', NULL),
-('01ac435f-fe3c-4af1-9979-f5e00467e7f5',4,'d28efb95-962d-4233-9002-827154bd76ad','3a297a4e-093a-4f9b-b201-1a994e2f4da7', NULL);
+INSERT INTO ipi_segment (instrument_id, id, length_timeseries_id, tilt_timeseries_id, inc_dev_timeseries_id, temp_timeseries_id) VALUES
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929',1,'bce99683-59bd-4e4b-ad79-64a03553cfdc','f7fa0d85-c684-4315-a7c6-e18e60667969','1bf787e9-8363-4047-8b03-fbaf9ff03eaf', '8d10fbd9-2669-4727-b4c1-746361691388'),
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929',2,'e891ca7c-59b2-41bc-9d4a-43995e35b855','258a5834-20bf-45fc-a60c-f245b2822592','4ffcb98f-962a-46ea-8923-8f992ef07c58', '6044cffb-c241-4b66-9873-068c2bbac451'),
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929',3,'18f17db2-4bc8-44cb-a9fa-ba84d13b8444','3bd67db5-abd6-4b35-a649-427791f9eeb7','1db6717b-6cde-4f46-b7fb-bc82b75051d7', '98385e5a-c5d8-4441-aa2e-0f6120414352'),
+('e29a8c6d-c5a4-4fcc-b269-3a60bd48f929',4,'d5c236cf-dca5-4a35-bc59-a9ecac4d572b','a3c4254b-1448-4f70-a1b6-d7f5e5c66eb7','6d90eb76-f292-461e-a82b-0faee9999778', 'c488fc08-18ff-4e3d-851f-46cfd1257b6c'),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',1,'88accf78-6f41-4342-86b5-026a8880cbb4','b2968456-b26a-4bbb-b8d9-f1217a6147ff', NULL, NULL),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',2,'fc332ef5-55a8-4657-9d6d-b0abeeb985f2','afcc8471-c91b-466e-833d-f173cc58797f', NULL, NULL),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',3,'a86c7468-09a7-4090-98e0-f7979103bbcd','26cb2cfa-910a-46c3-b03f-9dbcf823f8d8', NULL, NULL),
+('01ac435f-fe3c-4af1-9979-f5e00467e7f5',4,'d28efb95-962d-4233-9002-827154bd76ad','3a297a4e-093a-4f9b-b201-1a994e2f4da7', NULL, NULL);
 
 
 INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES
@@ -63,10 +66,10 @@ INSERT INTO timeseries_measurement (timeseries_id, time, value) VALUES
 INSERT INTO instrument_constants (timeseries_id, instrument_id) VALUES
 ('5842c707-b4be-4d10-a89c-1064e282e555','e29a8c6d-c5a4-4fcc-b269-3a60bd48f929'),
 ('7d515571-d6a2-4990-a1e2-d6d42049d864','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
-('bce99683-59bd-4e4b-ad79-64a03553cfdc','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
-('e891ca7c-59b2-41bc-9d4a-43995e35b855','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
-('18f17db2-4bc8-44cb-a9fa-ba84d13b8444','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
-('d5c236cf-dca5-4a35-bc59-a9ecac4d572b','eca4040e-aecb-4cd3-bcde-3e308f0356a6'),
+('bce99683-59bd-4e4b-ad79-64a03553cfdc','e29a8c6d-c5a4-4fcc-b269-3a60bd48f929'),
+('e891ca7c-59b2-41bc-9d4a-43995e35b855','e29a8c6d-c5a4-4fcc-b269-3a60bd48f929'),
+('18f17db2-4bc8-44cb-a9fa-ba84d13b8444','e29a8c6d-c5a4-4fcc-b269-3a60bd48f929'),
+('d5c236cf-dca5-4a35-bc59-a9ecac4d572b','e29a8c6d-c5a4-4fcc-b269-3a60bd48f929'),
 ('88accf78-6f41-4342-86b5-026a8880cbb4','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
 ('fc332ef5-55a8-4657-9d6d-b0abeeb985f2','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
 ('a86c7468-09a7-4090-98e0-f7979103bbcd','01ac435f-fe3c-4af1-9979-f5e00467e7f5'),
@@ -91,7 +94,11 @@ FROM
         'b2968456-b26a-4bbb-b8d9-f1217a6147ff'::UUID,
         'afcc8471-c91b-466e-833d-f173cc58797f'::UUID,
         '26cb2cfa-910a-46c3-b03f-9dbcf823f8d8'::UUID,
-        '3a297a4e-093a-4f9b-b201-1a994e2f4da7'::UUID
+        '3a297a4e-093a-4f9b-b201-1a994e2f4da7'::UUID,
+        '8d10fbd9-2669-4727-b4c1-746361691388'::UUID,
+        '6044cffb-c241-4b66-9873-068c2bbac451'::UUID,
+        '98385e5a-c5d8-4441-aa2e-0f6120414352'::UUID,
+        'c488fc08-18ff-4e3d-851f-46cfd1257b6c'::UUID
 ]) AS timeseries_id,
     generate_series(
         now() - INTERVAL '1 month',


### PR DESCRIPTION
## Description

Updated IPI fields to include
- Incremental Deviation instead of Cumulative for timeseries assignment (cumulative is calculated from rolling sum over bottom segments, ascending)
- Added optional temperature timeseries fields for IPI
- Fixed some inconsistencies in test data
- Use Feet by default for IPI and SAA default instrument constants