### PR TITLE
fix/equivalency table datalogger responses

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -543,8 +543,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.EquivalencyTable"
                         }
                     },
                     "400": {
@@ -793,8 +792,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.EquivalencyTable"
                         }
                     },
                     "400": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -535,8 +535,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.EquivalencyTable"
                         }
                     },
                     "400": {
@@ -785,8 +784,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/github_com_USACE_instrumentation-api_api_internal_model.EquivalencyTable"
                         }
                     },
                     "400": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1427,8 +1427,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.EquivalencyTable'
         "400":
           description: Bad Request
           schema:
@@ -1580,8 +1579,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/github_com_USACE_instrumentation-api_api_internal_model.EquivalencyTable'
         "400":
           description: Bad Request
           schema:

--- a/api/internal/handler/datalogger_telemetry.go
+++ b/api/internal/handler/datalogger_telemetry.go
@@ -46,7 +46,7 @@ func (h *TelemetryHandler) CreateOrUpdateDataloggerMeasurements(c echo.Context) 
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	var prv model.DataloggerPreview
+	var prv model.DataloggerTablePreview
 	if err := prv.Preview.Set(rawJSON); err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func getCR6Handler(h *TelemetryHandler, dl model.Datalogger, rawJSON []byte) ech
 		// reroute deferred errors and previews to respective table
 		tn = pl.Head.Environment.TableName
 
-		var prv model.DataloggerPreview
+		var prv model.DataloggerTablePreview
 		if err := prv.Preview.Set(rawJSON); err != nil {
 			return err
 		}

--- a/api/internal/handler/equivalency_table.go
+++ b/api/internal/handler/equivalency_table.go
@@ -47,7 +47,7 @@ func (h *ApiHandler) GetEquivalencyTable(c echo.Context) error {
 		if errors.Is(err, sql.ErrNoRows) {
 			return echo.NewHTTPError(http.StatusNotFound, message.NotFound)
 		}
-		return echo.NewHTTPError(http.StatusInternalServerError, message.InternalServerError)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, t)

--- a/api/internal/model/datalogger_telemetry.go
+++ b/api/internal/model/datalogger_telemetry.go
@@ -35,7 +35,7 @@ const updateDataloggerTablePreview = `
 	WHERE datalogger_table_id IN (SELECT id FROM datalogger_table WHERE datalogger_id = $1 AND table_name = $2)
 `
 
-func (q *Queries) UpdateDataloggerTablePreview(ctx context.Context, dataloggerID uuid.UUID, tableName string, dlp DataloggerPreview) error {
+func (q *Queries) UpdateDataloggerTablePreview(ctx context.Context, dataloggerID uuid.UUID, tableName string, dlp DataloggerTablePreview) error {
 	_, err := q.db.ExecContext(ctx, updateDataloggerTablePreview, dataloggerID, tableName, dlp.Preview, dlp.UpdateDate)
 	return err
 }

--- a/api/internal/model/equivalency_table.go
+++ b/api/internal/model/equivalency_table.go
@@ -69,6 +69,7 @@ const getEquivalencyTable = `
 	SELECT
 		datalogger_id,
 		datalogger_table_id,
+		datalogger_table_name,
 		fields
 	FROM v_datalogger_equivalency_table
 	WHERE datalogger_table_id = $1

--- a/api/internal/service/datalogger.go
+++ b/api/internal/service/datalogger.go
@@ -19,7 +19,7 @@ type DataloggerService interface {
 	GetOneDatalogger(ctx context.Context, dataloggerID uuid.UUID) (model.Datalogger, error)
 	UpdateDatalogger(ctx context.Context, u model.Datalogger) (model.Datalogger, error)
 	DeleteDatalogger(ctx context.Context, d model.Datalogger) error
-	GetDataloggerTablePreview(ctx context.Context, dataloggerTableID uuid.UUID) (model.DataloggerPreview, error)
+	GetDataloggerTablePreview(ctx context.Context, dataloggerTableID uuid.UUID) (model.DataloggerTablePreview, error)
 	ResetDataloggerTableName(ctx context.Context, dataloggerTableID uuid.UUID) error
 	GetOrCreateDataloggerTable(ctx context.Context, dataloggerID uuid.UUID, tableName string) (uuid.UUID, error)
 	DeleteDataloggerTable(ctx context.Context, dataloggerTableID uuid.UUID) error

--- a/api/internal/service/datalogger_telemetry.go
+++ b/api/internal/service/datalogger_telemetry.go
@@ -10,7 +10,7 @@ import (
 type DataloggerTelemetryService interface {
 	GetDataloggerByModelSN(ctx context.Context, modelName, sn string) (model.Datalogger, error)
 	GetDataloggerHashByModelSN(ctx context.Context, modelName, sn string) (string, error)
-	UpdateDataloggerTablePreview(ctx context.Context, dataloggerID uuid.UUID, tableName string, dlp model.DataloggerPreview) error
+	UpdateDataloggerTablePreview(ctx context.Context, dataloggerID uuid.UUID, tableName string, dlp model.DataloggerTablePreview) error
 	UpdateDataloggerTableError(ctx context.Context, dataloggerID uuid.UUID, tableName *string, e *model.DataloggerError) error
 }
 

--- a/migrate/common/R__10_datalogger.sql
+++ b/migrate/common/R__10_datalogger.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW v_datalogger AS (
+DROP VIEW IF EXISTS v_datalogger;
+CREATE VIEW v_datalogger AS (
     SELECT
         dl.id          AS id,
         dl.sn          AS sn,
@@ -41,7 +42,8 @@ CREATE OR REPLACE VIEW v_datalogger AS (
     WHERE NOT dl.deleted
 );
 
-CREATE OR REPLACE VIEW v_datalogger_preview AS (
+DROP VIEW IF EXISTS v_datalogger_preview;
+CREATE VIEW v_datalogger_preview AS (
     SELECT
         p.datalogger_table_id,
         p.preview,
@@ -52,10 +54,12 @@ CREATE OR REPLACE VIEW v_datalogger_preview AS (
     WHERE NOT dl.deleted
 );
 
-CREATE OR REPLACE VIEW v_datalogger_equivalency_table AS (
+DROP VIEW IF EXISTS v_datalogger_equivalency_table;
+CREATE VIEW v_datalogger_equivalency_table AS (
     SELECT
         dt.datalogger_id AS datalogger_id,
         dt.id AS datalogger_table_id,
+        dt.table_name AS datalogger_table_name,
         COALESCE(JSON_AGG(ROW_TO_JSON(eq)) FILTER (WHERE eq IS NOT NULL), '[]'::JSON)::TEXT AS fields
     FROM datalogger_table dt
     INNER JOIN datalogger dl ON dt.datalogger_id = dl.id
@@ -68,7 +72,8 @@ CREATE OR REPLACE VIEW v_datalogger_equivalency_table AS (
     GROUP BY dt.datalogger_id, dt.id
 );
 
-CREATE OR REPLACE VIEW v_datalogger_hash AS (
+DROP VIEW IF EXISTS v_datalogger_hash;
+CREATE VIEW v_datalogger_hash AS (
     SELECT
         dh.datalogger_id AS datalogger_id,
         dh.hash          AS "hash",

--- a/migrate/common/R__10_datalogger.sql
+++ b/migrate/common/R__10_datalogger.sql
@@ -60,7 +60,7 @@ CREATE VIEW v_datalogger_equivalency_table AS (
         dt.datalogger_id AS datalogger_id,
         dt.id AS datalogger_table_id,
         dt.table_name AS datalogger_table_name,
-        COALESCE(JSON_AGG(ROW_TO_JSON(eq)) FILTER (WHERE eq IS NOT NULL), '[]'::JSON)::TEXT AS fields
+        COALESCE(JSON_AGG(ROW_TO_JSON(eq)) FILTER (WHERE eq.id IS NOT NULL), '[]'::JSON)::TEXT AS fields
     FROM datalogger_table dt
     INNER JOIN datalogger dl ON dt.datalogger_id = dl.id
     LEFT JOIN LATERAL (

--- a/migrate/local/V999.1.0__seed_data.sql
+++ b/migrate/local/V999.1.0__seed_data.sql
@@ -94,7 +94,8 @@ INSERT INTO timeseries (id, instrument_id, parameter_id, unit_id, slug, name) VA
 ('5b6f4f37-7755-4cf9-bd02-94f1e9bc5984', 'a7540f69-c41e-43b3-b655-6e44097edb7e', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'demo-piezometer-1.formula', 'demo-piezometer-1'),
 ('5b6f4f37-7755-4cf9-bd02-94f1e9bc5985', '9e8f2ca4-4037-45a4-aaca-d9e598877439', '2b7f96e1-820f-4f61-ba8f-861640af6232', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'demo-staffgage-1.formula', 'demo-staffgage-1'),
 ('5b6f4f37-7755-4cf9-bd02-94f1e9bc5986', 'd8c66ef9-06f0-4d52-9233-f3778e0624f0', '068b59b0-aafb-4c98-ae4b-ed0365a6fbac', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'inclinometer-1.formula', 'inclinometer-1'),
-('844fb688-e77c-481e-bff9-81a0fff9f3f2', 'd8c66ef9-06f0-4d52-9233-f3778e0624f0', '068b59b0-aafb-4c98-ae4b-ed0365a6fbac', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'test-create-datalogger-table-mapping', 'test-create-datalogger-table-mapping');
+('844fb688-e77c-481e-bff9-81a0fff9f3f2', 'd8c66ef9-06f0-4d52-9233-f3778e0624f0', '068b59b0-aafb-4c98-ae4b-ed0365a6fbac', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'test-create-datalogger-table-mapping', 'test-create-datalogger-table-mapping'),
+('da79bdb9-ded4-4f4a-8982-33e09b136815', 'd8c66ef9-06f0-4d52-9233-f3778e0624f0', '068b59b0-aafb-4c98-ae4b-ed0365a6fbac', '4a999277-4cf5-4282-93ce-23b33c65e2c8', 'test-table-mapping', 'test-table-mapping');
 
 INSERT INTO calculation (timeseries_id, contents) VALUES
 ('5b6f4f37-7755-4cf9-bd02-94f1e9bc5984', '[demo-piezometer-1.top-of-riser] - [demo-piezometer-1.distance-to-water]'),

--- a/migrate/local/V999.4.0__seed_datalogger.sql
+++ b/migrate/local/V999.4.0__seed_datalogger.sql
@@ -17,4 +17,4 @@ INSERT INTO datalogger_preview (datalogger_table_id, update_date, preview) VALUE
 
 INSERT INTO datalogger_equivalency_table (id, datalogger_table_id, datalogger_id, datalogger_deleted, field_name, display_name, instrument_id, timeseries_id) VALUES
     ('40ceff10-cdc3-4715-a4ca-c1e570fe25de', '98a77c65-e5c4-49ed-8fb4-b0ffd06add4c', '83a7345c-62d8-4e29-84db-c2e36f8bc40d', false, 'batt_volt_Min', 'Battery Voltage', '9e8f2ca4-4037-45a4-aaca-d9e598877439', '8f4ca3a3-5971-4597-bd6f-332d1cf5af7c'),
-    ('2f1f7c3d-8b6f-4b11-917e-8f049eb6c62b', '98a77c65-e5c4-49ed-8fb4-b0ffd06add4c', '83a7345c-62d8-4e29-84db-c2e36f8bc40d', false, 'PanelT', 'Panel Temperature', 'a7540f69-c41e-43b3-b655-6e44097edb7e', 'd9697351-3a38-4194-9ac4-41541927e475');
+    ('2f1f7c3d-8b6f-4b11-917e-8f049eb6c62b', '98a77c65-e5c4-49ed-8fb4-b0ffd06add4c', '83a7345c-62d8-4e29-84db-c2e36f8bc40d', false, 'PanelT', 'Panel Temperature', 'a7540f69-c41e-43b3-b655-6e44097edb7e', 'da79bdb9-ded4-4f4a-8982-33e09b136815');


### PR DESCRIPTION
## Description

- Fixes issue where equivalency table POST succeeds but does not return rows in response.
- Returns `null` string for datalogger JSON preview in case where datalogger exists and preview does not, instead of returning 404 Not Found.