### PR TITLE
add ./compose.sh watch command for core api development

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,5 @@
-# options: dev | prod
-ARG BUILD_ENV=prod
 ARG BASE_IMAGE=scratch
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.21
 
 FROM golang:${GO_VERSION}-alpine AS builder
 
@@ -11,36 +9,35 @@ ARG BUILD_ENV
 RUN apk update && apk add --no-cache git ca-certificates
 WORKDIR /go/src/app
 
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
 ENV CGO_ENABLED=0
-COPY go.* ./
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+COPY --chown=appgroup:appuser go.* ./
 RUN go mod download
 
-COPY . .
+COPY --chown=appgroup:appuser . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOFLAGS=$([ "$BUILD_ENV" = "dev" ] && echo "-gcflags=all=-N -gcflags=all=-l" || echo "-ldflags=-w -ldflags=-s") \
     GOOS=linux GOARCH=${GOARCH} \
     go build -ldflags="-w -s" -o /go/bin ./...
 
-FROM golang:${GO_VERSION}-alpine AS build_dev
-ONBUILD RUN go install github.com/cosmtrek/air@latest
-ONBUILD RUN go install github.com/go-delve/delve/cmd/dlv@latest
-
-FROM $BASE_IMAGE AS build_prod
-
-FROM build_${BUILD_ENV} AS core
+FROM ${BASE_IMAGE} AS core
 COPY --from=builder /go/bin/core /go/bin/midas-core
 ENTRYPOINT ["/go/bin/midas-core"]
 
-FROM build_${BUILD_ENV} AS telemetry
+FROM ${BASE_IMAGE} AS telemetry
 COPY --from=builder /go/bin/telemetry /go/bin/midas-telemetry
 ENTRYPOINT ["/go/bin/midas-telemetry"]
 
-FROM build_${BUILD_ENV} AS alert
+FROM ${BASE_IMAGE} AS alert
 COPY --from=builder /go/bin/alert /go/bin/midas-alert
 ENTRYPOINT ["/go/bin/midas-alert"]
 
-FROM build_${BUILD_ENV} AS dcs-loader
+FROM ${BASE_IMAGE} AS dcs-loader
 COPY --from=builder /go/bin/dcs-loader /go/bin/midas-dcs-loader
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/go/bin/midas-dcs-loader"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,9 +3,15 @@ version: "3.9"
 services:
   api:
     build:
-      args:
-        - BUILD_ENV=dev
       target: builder
+    entrypoint: go run cmd/core/main.go
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./api
+          target: /go/src/app
+          ignore:
+            - docs/
     depends_on:
       alert:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,6 @@ services:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
-      alert:
-        condition: service_started
 
   telemetry:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
+      alert:
+        condition: service_started
 
   telemetry:
     build:
@@ -151,8 +153,6 @@ services:
     ports:
       - "9324:9324"
     restart: unless-stopped
-
-  # ---------------------- local profile services ---------------------- #
 
   minio:
     image: minio/minio


### PR DESCRIPTION
## Description

- bump go from 1.20 to 1.21
- add `docker compose watch` functionality for syncing files in core api container and local dev environment
  - https://docs.docker.com/compose/file-watch/
  - add user roles to builder to allow file watching
- enhance compose script