### PR TITLE
Fix/instrument project create assign

### DIFF
--- a/api/internal/model/instrument.go
+++ b/api/internal/model/instrument.go
@@ -235,6 +235,16 @@ func (q *Queries) UnassignInstrumentFromProject(ctx context.Context, projectID, 
 	return err
 }
 
+const getProjectCountForInstrument = `
+	SELECT COUNT(*) FROM project_instrument WHERE instrument_id = $1
+`
+
+func (q *Queries) GetProjectCountForInstrument(ctx context.Context, instrumentID uuid.UUID) (int, error) {
+	var count int
+	err := q.db.GetContext(ctx, &count, getProjectCountForInstrument, instrumentID)
+	return count, err
+}
+
 const validateCreateInstruments = ` 
 	SELECT pi.project_id, i.name
 	FROM project_instrument pi

--- a/api/internal/service/instrument.go
+++ b/api/internal/service/instrument.go
@@ -52,7 +52,7 @@ func createInstrument(ctx context.Context, q *model.Queries, instrument model.In
 		return model.IDSlugName{}, err
 	}
 	for _, prj := range instrument.Projects {
-		if err := q.AssignInstrumentToProject(ctx, prj.ID, instrument.ID); err != nil {
+		if err := q.AssignInstrumentToProject(ctx, prj.ID, newInstrument.ID); err != nil {
 			return model.IDSlugName{}, err
 		}
 	}

--- a/api/internal/service/instrument.go
+++ b/api/internal/service/instrument.go
@@ -51,6 +51,11 @@ func createInstrument(ctx context.Context, q *model.Queries, instrument model.In
 	if err != nil {
 		return model.IDSlugName{}, err
 	}
+	for _, prj := range instrument.Projects {
+		if err := q.AssignInstrumentToProject(ctx, prj.ID, instrument.ID); err != nil {
+			return model.IDSlugName{}, err
+		}
+	}
 	if err := q.CreateOrUpdateInstrumentStatus(ctx, newInstrument.ID, instrument.StatusID, instrument.StatusTime); err != nil {
 		return model.IDSlugName{}, err
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,7 @@
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=


### PR DESCRIPTION
## Description
- Fix issue where creating instrument would return successfully but not link to existing project
- When unassigning a project from an instrument, check that there are other projects which the instrument can be accessed from. If not, throw an error.