### PR TITLE
Remove timeseries measurement BTREE/BRIN indexes

### DIFF
--- a/migrate/common/V3.0.3__drop_timeseries_measurement_idx.sql
+++ b/migrate/common/V3.0.3__drop_timeseries_measurement_idx.sql
@@ -1,0 +1,10 @@
+-- large index created during troubleshooting
+-- this was for the explorer / calculated timeseries endpoints
+-- other (smaller) indexes were created afterwards that solve
+-- those quesry performance issues
+DROP INDEX IF EXISTS timeseries_measurement_btree_idx;
+
+-- this has little benefit due to the amout of manually uploaded
+-- and backfilled timeseries data, only works well if there is
+-- correlation between insertion order and index (time)
+DROP INDEX IF EXISTS timeseries_measurement_time_brin_idx;


### PR DESCRIPTION
Remove indexes that were added for testing purposes on large explorer/calculated timeseries query.

These indexes were created for testing purpose. Testing has been performed on large tables after deleting these indexes which have no resulting regressions.