### PR TITLE
Fix new plot type bugs

### DIFF
--- a/api/internal/model/instrument.go
+++ b/api/internal/model/instrument.go
@@ -182,7 +182,7 @@ func (q *Queries) GetInstrumentCount(ctx context.Context) (InstrumentCount, erro
 
 const createInstrument = `
 	INSERT INTO instrument (slug, name, type_id, geometry, station, station_offset, creator, create_date, nid_id, usgs_id)
-	VALUES (slugify($1, 'instrument'), $1, $2, ST_GeomFromWKB($3), $4, $5, $6, $7, $8, $9)
+	VALUES (slugify($1, 'instrument'), $1, $2, ST_SetSRID(ST_GeomFromWKB($3), 4326), $4, $5, $6, $7, $8, $9)
 	RETURNING id, slug
 `
 

--- a/migrate/common/R__09_views_plots.sql
+++ b/migrate/common/R__09_views_plots.sql
@@ -32,7 +32,10 @@ CREATE OR REPLACE VIEW v_plot_configuration AS (
             )::text
             WHEN pc.plot_type = 'contour' THEN json_build_object(
                 'timeseries_ids', COALESCE(pcct.timeseries_ids, '{}'),
-                'time', to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.US') || 'Z',
+                'time', CASE
+                    WHEN pcc.time IS NULL THEN NULL
+                    ELSE to_char(pcc.time, 'YYYY-MM-DD"T"HH24:MI:SS.US') || 'Z'
+                END,
                 'locf_backfill', pcc.locf_backfill,
                 'gradient_smoothing', pcc.gradient_smoothing,
                 'contour_smoothing', pcc.contour_smoothing,

--- a/migrate/common/V3.3.1__contour_time_nullable.sql
+++ b/migrate/common/V3.3.1__contour_time_nullable.sql
@@ -1,0 +1,3 @@
+ALTER TABLE plot_contour_config ALTER COLUMN time DROP NOT NULL;
+
+SELECT UpdateGeometrySRID('midas', 'instrument', 'geometry', 4326);


### PR DESCRIPTION
## Description

Issues:

- Contour plot needs to query available timeseries measurements in order to get valid time parameter. It needs to save the timeseries to the plot config to do this. Currently, if the timestamp is empty, and incorrect "zero" timestamp is used
- Contour plot measurements sometimes fail if the geometry data SRID is not set

This PR makes the following changes to fix them:

- Make time nullable for contour plot display
- Ensure instrument geometry metadata tagged as EPSG 4326 in PostGIS