### PR TITLE
Enforce email suffix

### DIFF
--- a/api/internal/httperr/httperr.go
+++ b/api/internal/httperr/httperr.go
@@ -58,3 +58,7 @@ func MalformedBody(err error) *echo.HTTPError {
 func MalformedDate(err error) *echo.HTTPError {
 	return Error(http.StatusBadRequest, "malformed date - use RFC3339 format", err)
 }
+
+func ForbiddenRole(err error) *echo.HTTPError {
+	return Error(418, "forbidden role", err)
+}

--- a/api/internal/middleware/audit.go
+++ b/api/internal/middleware/audit.go
@@ -157,10 +157,10 @@ func (m *mw) IsApplicationAdmin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		p, ok := c.Get("profile").(model.Profile)
 		if !ok {
-			return httperr.Forbidden(errors.New("could not bind profile from context"))
+			return httperr.Unauthorized(errors.New("could not bind profile from context"))
 		}
 		if !p.IsAdmin {
-			return httperr.Forbidden(errors.New("attempted application admin access failure"))
+			return httperr.ForbiddenRole(errors.New("attempted application admin access failure"))
 		}
 		return next(c)
 	}
@@ -172,18 +172,18 @@ func (m *mw) IsProjectAdmin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		p, ok := c.Get("profile").(model.Profile)
 		if !ok {
-			return httperr.Forbidden(errors.New("could not bind profile from context"))
+			return httperr.Unauthorized(errors.New("could not bind profile from context"))
 		}
 		if p.IsAdmin {
 			return next(c)
 		}
 		projectID, err := uuid.Parse(c.Param("project_id"))
 		if err != nil {
-			return httperr.Forbidden(err)
+			return httperr.MalformedID(err)
 		}
 		authorized, err := m.ProjectRoleService.IsProjectAdmin(c.Request().Context(), p.ID, projectID)
 		if err != nil || !authorized {
-			return httperr.Forbidden(err)
+			return httperr.ForbiddenRole(err)
 		}
 		return next(c)
 	}
@@ -195,18 +195,18 @@ func (m *mw) IsProjectMember(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		p, ok := c.Get("profile").(model.Profile)
 		if !ok {
-			return httperr.Forbidden(errors.New("could not bind profile from context"))
+			return httperr.Unauthorized(errors.New("could not bind profile from context"))
 		}
 		if p.IsAdmin {
 			return next(c)
 		}
 		projectID, err := uuid.Parse(c.Param("project_id"))
 		if err != nil {
-			return httperr.Forbidden(err)
+			return httperr.MalformedID(err)
 		}
 		authorized, err := m.ProjectRoleService.IsProjectMember(c.Request().Context(), p.ID, projectID)
 		if err != nil || !authorized {
-			return httperr.Forbidden(err)
+			return httperr.ForbiddenRole(err)
 		}
 		return next(c)
 	}

--- a/api/internal/middleware/audit.go
+++ b/api/internal/middleware/audit.go
@@ -83,14 +83,7 @@ func (m *mw) AttachClaims(next echo.HandlerFunc) echo.HandlerFunc {
 			return httperr.Forbidden(err)
 		}
 
-		email := strings.ToLower(claims.Email)
-		allowEmail := false
-		for _, suf := range m.cfg.AuthAllowEmailSuffixes {
-			if strings.HasSuffix(email, suf) {
-				allowEmail = true
-			}
-		}
-		if !allowEmail {
+		if email := strings.ToLower(claims.Email); !strings.HasSuffix(email, "usace.army.mil") && !strings.HasSuffix(email, "erdc.dren.mil") && email != "midas@rsgis.dev" {
 			return httperr.Forbidden(errors.New("email forbidden"))
 		}
 


### PR DESCRIPTION
## Description

- Revert to using hardcoded email suffixes due to constraints on adding env vars.
- Use distinct HTTP error for cases where the user role is invalid vs in invalid email